### PR TITLE
Add output_only mode to output response instead of posting comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,15 @@ inputs:
     required: false
     default: 'true'
 
+  output_only:
+    description: 'When true, outputs the response text instead of posting a comment'
+    required: false
+    default: 'false'
+
+outputs:
+  response:
+    description: 'The agent response text (only populated when output_only is true)'
+
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,7 +60,7 @@ export default [
     },
   },
   {
-    files: ["tests/**/*.spec.ts"],
+    files: ["tests/**/*.spec.ts", "tests/**/*.ts"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/src/adapters/core-adapter.ts
+++ b/src/adapters/core-adapter.ts
@@ -34,4 +34,8 @@ export class RealCoreAdapter implements CoreAdapter {
   warning(message: string): void {
     core.warning(message);
   }
+
+  setOutput(name: string, value: string): void {
+    core.setOutput(name, value);
+  }
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -94,6 +94,11 @@ export class ActionOrchestrator {
       ? loadBuiltinExtensionsInput.toLowerCase() === 'true'
       : true; // default to true
 
+    const outputOnlyInput = this.core.getInput('output_only');
+    const outputOnly = outputOnlyInput
+      ? outputOnlyInput.toLowerCase() === 'true'
+      : false;
+
     return {
       provider: this.core.getInput('provider'),
       model: this.core.getInput('model'),
@@ -102,11 +107,12 @@ export class ActionOrchestrator {
       promptInput: this.core.getInput('prompt'),
       ...(extensions?.length ? { extensions } : {}),
       loadBuiltinExtensions,
+      outputOnly,
     };
   }
 
   /**
-   * Finalize execution by posting the result/error as a comment.
+   * Finalize execution by posting the result/error as a comment or setting output.
    */
   private async finalize(
     body: string,
@@ -122,6 +128,11 @@ export class ActionOrchestrator {
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
       this.core.notice(`failed to delete reaction: ${errorMessage}`);
+    }
+
+    if (config.outputOnly) {
+      this.core.setOutput('response', body);
+      return;
     }
 
     const metadata: CommentMetadata = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface CoreAdapter {
   info(message: string): void;
   /** Log a warning message. */
   warning(message: string): void;
+  /** Set an action output. */
+  setOutput(name: string, value: string): void;
 }
 
 /**
@@ -97,6 +99,7 @@ export interface PiConfig {
   promptInput: string;
   extensions?: string[];
   loadBuiltinExtensions?: boolean;
+  outputOnly?: boolean;
 }
 
 /**

--- a/tests/e2e/pi-agent.spec.ts
+++ b/tests/e2e/pi-agent.spec.ts
@@ -63,6 +63,7 @@ const mockNotice = mock();
 const mockInfo = mock();
 const mockDebug = mock();
 const mockWarning = mock();
+const mockSetOutput = mock();
 
 import type { CoreAdapter } from '../../src/types.ts';
 
@@ -73,6 +74,7 @@ const mockCoreAdapter: CoreAdapter = {
   debug: mockDebug,
   info: mockInfo,
   warning: mockWarning,
+  setOutput: mockSetOutput,
 };
 
 mock.module('@actions/core', () => ({
@@ -82,6 +84,7 @@ mock.module('@actions/core', () => ({
   debug: mockDebug,
   setFailed: mockSetFailed,
   warning: mockWarning,
+  setOutput: mockSetOutput,
 }));
 
 // Mock @actions/github context

--- a/tests/github.spec.ts
+++ b/tests/github.spec.ts
@@ -40,6 +40,7 @@ const testCoreAdapter = {
   info: mock(noop),
   debug: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 };
 
 mock.module('@actions/core', () => ({
@@ -49,6 +50,7 @@ mock.module('@actions/core', () => ({
   debug: mock(noop),
   setFailed: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 }));
 
 import * as github from '@actions/github';

--- a/tests/github/comments.spec.ts
+++ b/tests/github/comments.spec.ts
@@ -35,6 +35,7 @@ mock.module('@actions/core', () => ({
   debug: mock(debugLogger),
   setFailed: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 }));
 
 // Create a test CoreAdapter
@@ -47,6 +48,7 @@ const testCoreAdapter = {
   notice: mock(noop),
   info: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 };
 
 // Mock @actions/github context

--- a/tests/github/git/file-scanner.spec.ts
+++ b/tests/github/git/file-scanner.spec.ts
@@ -37,6 +37,7 @@ mock.module('@actions/core', () => ({
   debug: mock(noop),
   setFailed: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 }));
 
 // Set env vars BEFORE importing modules
@@ -83,6 +84,7 @@ const mockCoreAdapter = {
   info: mock(noop),
   debug: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 };
 
 describe('nested .gitignore support', () => {

--- a/tests/github/pull-request-update-integration.spec.ts
+++ b/tests/github/pull-request-update-integration.spec.ts
@@ -31,6 +31,7 @@ mock.module('@actions/core', () => ({
   debug: mock(noop),
   setFailed: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 }));
 
 // Set env vars BEFORE importing pull-request-update.ts
@@ -134,6 +135,7 @@ const testCoreAdapter = {
   info: mock(noop),
   debug: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 };
 
 // Dynamic import to ensure mocks are set before module loads

--- a/tests/github/reactions.spec.ts
+++ b/tests/github/reactions.spec.ts
@@ -36,6 +36,7 @@ mock.module('@actions/core', () => ({
   debug: mock(debugLogger),
   setFailed: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 }));
 
 // Set env vars BEFORE importing reactions.ts
@@ -101,6 +102,7 @@ const testCoreAdapter = {
   notice: mock(noop),
   info: mock(noop),
   warning: mock(noop),
+  setOutput: mock(noop),
 };
 
 const githubModulePromise = import('../../src/github/index.js');

--- a/tests/orchestrator.spec.ts
+++ b/tests/orchestrator.spec.ts
@@ -19,6 +19,7 @@ import { Temporal } from '@js-temporal/polyfill';
 import { ActionOrchestrator } from '../src/orchestrator';
 import type { CoreAdapter, GitHubAdapter, PiAgent } from '../src/types';
 import type { CreateReactionType } from '../src/github/reactions';
+import { createMockCoreAdapter } from './test-helpers';
 
 describe('ActionOrchestrator', () => {
   let mockCore: CoreAdapter;
@@ -28,7 +29,7 @@ describe('ActionOrchestrator', () => {
 
   beforeEach(() => {
     // Create mock core adapter
-    const getInputMock = mock((name: string) => {
+    const getInputMock = mock((name: string): string => {
       const defaults: Record<string, string> = {
         provider: 'anthropic',
         model: 'claude-sonnet-4-5',
@@ -36,22 +37,12 @@ describe('ActionOrchestrator', () => {
         thinking_level: '',
         prompt: '',
       };
-      return defaults[name];
+      return defaults[name] ?? '';
     });
 
-    const setFailedMock = mock();
-    const noticeMock = mock();
-    const infoMock = mock();
-    const debugMock = mock();
-    const warningMock = mock();
-    mockCore = {
+    mockCore = createMockCoreAdapter({
       getInput: getInputMock,
-      setFailed: setFailedMock,
-      notice: noticeMock,
-      info: infoMock,
-      debug: debugMock,
-      warning: warningMock,
-    } as any;
+    });
 
     // Create mock github adapter
     const addReactionMock = mock(async () => ({ data: { id: 123 } }) as CreateReactionType);
@@ -157,6 +148,7 @@ describe('ActionOrchestrator', () => {
           thinkingLevel: 'medium',
           promptInput: '',
           loadBuiltinExtensions: true, // default value
+          outputOnly: false, // default value
         },
         mockCore
       );
@@ -190,6 +182,7 @@ describe('ActionOrchestrator', () => {
           thinkingLevel: '', // Empty string, because ?? doesn't apply to empty strings
           promptInput: '',
           loadBuiltinExtensions: true, // default value
+          outputOnly: false, // default value
         },
         mockCore
       );
@@ -800,6 +793,85 @@ describe('ActionOrchestrator', () => {
 
       expect(mockCore.setFailed).toHaveBeenCalledWith(error);
       expect(mockCore.setFailed).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('output_only mode', () => {
+    test('sets output instead of posting comment when output_only is true', async () => {
+      const getInputMock = mock((name: string): string => {
+        const inputs: Record<string, string> = {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          token: 'test-token',
+          thinking_level: '',
+          prompt: '',
+          output_only: 'true',
+        };
+        return inputs[name] ?? '';
+      });
+      mockCore.getInput = getInputMock as any;
+
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockCore.setOutput).toHaveBeenCalledWith('response', 'Here are your tests!');
+      expect(mockGithub.createFinalComment).not.toHaveBeenCalled();
+    });
+
+    test('posts comment when output_only is false', async () => {
+      const getInputMock = mock((name: string): string => {
+        const inputs: Record<string, string> = {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          token: 'test-token',
+          thinking_level: '',
+          prompt: '',
+          output_only: 'false',
+        };
+        return inputs[name] ?? '';
+      });
+      mockCore.getInput = getInputMock as any;
+
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockCore.setOutput).not.toHaveBeenCalled();
+      expect(mockGithub.createFinalComment).toHaveBeenCalled();
+    });
+
+    test('defaults to posting comment when output_only not provided', async () => {
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockCore.setOutput).not.toHaveBeenCalled();
+      expect(mockGithub.createFinalComment).toHaveBeenCalled();
+    });
+
+    test('sets output with error message when output_only is true and execution fails', async () => {
+      const getInputMock = mock((name: string): string => {
+        const inputs: Record<string, string> = {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          token: 'test-token',
+          thinking_level: '',
+          prompt: '',
+          output_only: 'true',
+        };
+        return inputs[name] ?? '';
+      });
+      mockCore.getInput = getInputMock as any;
+
+      const error = new Error('API failed');
+      const runMock = mock(async () => {
+        throw error;
+      });
+      mockPiAgent.run = runMock as any;
+
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await expect(orchestrator.execute()).rejects.toThrow('API failed');
+
+      expect(mockCore.setOutput).toHaveBeenCalledWith('response', 'API failed');
+      expect(mockGithub.createFinalComment).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/pi/logging.spec.ts
+++ b/tests/pi/logging.spec.ts
@@ -121,6 +121,7 @@ describe('createLoggingFactory', () => {
       debug: () => {},
       info: () => {},
       warning: () => {},
+      setOutput: () => {},
     };
 
     const factory = createLoggingFactory(mockCore);
@@ -144,6 +145,7 @@ describe('createLoggingFactory', () => {
       debug: () => {},
       info: () => {},
       warning: () => {},
+      setOutput: () => {},
     };
 
     const extensionInfo: ExtensionLoadingInfo = {

--- a/tests/pi/resource-loader.spec.ts
+++ b/tests/pi/resource-loader.spec.ts
@@ -23,6 +23,7 @@ const mockCoreAdapter = {
   debug: mock(),
   info: mock(),
   warning: mock(),
+  setOutput: mock(),
 };
 
 // Set env vars before importing

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * @file Test helper utilities for creating mock adapters.
+ */
+
+import { mock } from 'bun:test';
+import type { CoreAdapter } from '../src/types';
+
+/**
+ * Create a mock CoreAdapter with all required methods.
+ */
+export function createMockCoreAdapter(overrides?: Partial<CoreAdapter>): CoreAdapter {
+  return {
+    getInput: mock(() => ''),
+    setFailed: mock(() => {}),
+    notice: mock(() => {}),
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warning: mock(() => {}),
+    setOutput: mock(() => {}),
+    ...overrides,
+  } as CoreAdapter;
+}


### PR DESCRIPTION
## Summary

Adds an `output_only` input option that allows the action to output the Pi agent's response as an action output instead of posting it as a GitHub comment.

## Changes

- **action.yml**: Added `output_only` input (default: `false`) and `response` output
- **orchestrator.ts**: Updated finalize logic to conditionally post comments or set output based on `output_only` flag
- **types.ts**: Added `outputOnly` to `PiConfig` and `setOutput` to `CoreAdapter` interface
- **core-adapter.ts**: Implemented `setOutput` method
- **tests**: Added comprehensive tests for output_only mode and updated all test mocks

## Usage

```yaml
- uses: mcowger/pi-coding-agent-action@v2
  with:
    output_only: true
    provider: anthropic
    model: claude-sonnet-4-5
    token: ${{ secrets.ANTHROPIC_API_KEY }}
    prompt: 'Analyze this code'
  id: pi

- name: Use the response
  run: echo "${{ steps.pi.outputs.response }}"
```

## Testing

All existing tests pass, plus new tests covering:
- Output mode sets output instead of posting comment
- Default behavior (posts comment) is preserved
- Error messages are output correctly in output_only mode