### PR TITLE
feat: add pi_models_json input for custom model registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
     required: false
     default: 'true'
 
+  pi_models_json:
+    description: 'Contents of ~/.pi/agent/models.json for custom model definitions. When provided, overrides or merges with the built-in model registry.'
+    required: false
+    default: ''
+
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/src/adapters/pi-agent-adapter.ts
+++ b/src/adapters/pi-agent-adapter.ts
@@ -18,7 +18,8 @@ export const createRealPiAgent: PiAgentFactory = (config: PiConfig, core): PiAge
     config.thinkingLevel,
     core,
     config.extensions,
-    config.loadBuiltinExtensions
+    config.loadBuiltinExtensions,
+    config.modelsJson
   );
 
   return {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -94,6 +94,8 @@ export class ActionOrchestrator {
       ? loadBuiltinExtensionsInput.toLowerCase() === 'true'
       : true; // default to true
 
+    const modelsJsonInput = this.core.getInput('pi_models_json');
+
     return {
       provider: this.core.getInput('provider'),
       model: this.core.getInput('model'),
@@ -102,6 +104,7 @@ export class ActionOrchestrator {
       promptInput: this.core.getInput('prompt'),
       ...(extensions?.length ? { extensions } : {}),
       loadBuiltinExtensions,
+      ...(modelsJsonInput ? { modelsJson: modelsJsonInput } : {}),
     };
   }
 

--- a/src/pi/agent.ts
+++ b/src/pi/agent.ts
@@ -6,7 +6,14 @@
  * headless / non-interactive use inside GitHub Actions.
  */
 
-import { AuthStorage, createAgentSession, ModelRegistry } from '@mariozechner/pi-coding-agent';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  AuthStorage,
+  createAgentSession,
+  getAgentDir,
+  ModelRegistry,
+} from '@mariozechner/pi-coding-agent';
 import { getResourceLoader } from './resource-loader';
 import { getVersion } from './logging';
 
@@ -34,6 +41,7 @@ export class Agent {
   private core: CoreAdapter;
   private extensions?: string[];
   private loadBuiltinExtensions?: boolean;
+  private modelsJson?: string;
 
   /**
    * Create a new Pi agent.
@@ -48,6 +56,7 @@ export class Agent {
    * @param core                  - The CoreAdapter for logging and debug output.
    * @param extensions            - Optional array of extension sources (npm, git, or local paths).
    * @param loadBuiltinExtensions - Whether to load built-in GitHub extensions (default true).
+   * @param modelsJson            - Optional contents of ~/.pi/agent/models.json for custom model definitions.
    * @throws {Error}   If the requested model cannot be found in the registry.
    */
   constructor(
@@ -57,7 +66,8 @@ export class Agent {
     level = 'off',
     core: CoreAdapter,
     extensions?: string[],
-    loadBuiltinExtensions?: boolean
+    loadBuiltinExtensions?: boolean,
+    modelsJson?: string
   ) {
     this.modelStr = modelStr;
     this.provider = provider;
@@ -70,7 +80,18 @@ export class Agent {
     if (loadBuiltinExtensions !== undefined) {
       this.loadBuiltinExtensions = loadBuiltinExtensions;
     }
-    this.modelRegistry = ModelRegistry.inMemory(this.authStorage);
+    if (modelsJson !== undefined) {
+      this.modelsJson = modelsJson;
+    }
+
+    // If modelsJson is provided, write it to disk and use ModelRegistry.create()
+    // which loads built-in models + custom models from models.json
+    if (this.modelsJson) {
+      this.writeModelsJson(this.modelsJson);
+      this.modelRegistry = ModelRegistry.create(this.authStorage);
+    } else {
+      this.modelRegistry = ModelRegistry.inMemory(this.authStorage);
+    }
 
     if (this.token) {
       this.core.debug(`[auth] Setting api_key token for ${this.provider} provider`);
@@ -87,6 +108,22 @@ export class Agent {
     } else {
       throw new Error('Model not found: ' + this.provider + '/' + this.modelStr);
     }
+  }
+
+  /**
+   * Write models.json content to disk so ModelRegistry.create() can load it.
+   *
+   * Creates the ~/.pi/agent directory if needed and writes the JSON content
+   * to the models.json file. This allows custom model definitions to be
+   * merged with or override the built-in model registry.
+   *
+   * @param content - The JSON string content for models.json.
+   */
+  private writeModelsJson(content: string): void {
+    const agentDir = getAgentDir();
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'models.json'), content);
+    this.core.debug(`[models] Wrote custom models.json to ${join(agentDir, 'models.json')}`);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export interface PiConfig {
   promptInput: string;
   extensions?: string[];
   loadBuiltinExtensions?: boolean;
+  /** Contents of ~/.pi/agent/models.json for custom model definitions */
+  modelsJson?: string;
 }
 
 /**

--- a/tests/orchestrator.spec.ts
+++ b/tests/orchestrator.spec.ts
@@ -90,6 +90,7 @@ describe('ActionOrchestrator', () => {
       expect(mockCore.getInput).toHaveBeenCalledWith('token');
       expect(mockCore.getInput).toHaveBeenCalledWith('thinking_level');
       expect(mockCore.getInput).toHaveBeenCalledWith('prompt');
+      expect(mockCore.getInput).toHaveBeenCalledWith('pi_models_json');
     });
 
     test('retrieves prompt from github', async () => {
@@ -637,6 +638,70 @@ describe('ActionOrchestrator', () => {
         }),
         mockCore
       );
+    });
+  });
+
+  describe('pi_models_json configuration', () => {
+    test('passes modelsJson to Pi agent when provided', async () => {
+      const modelsJson = JSON.stringify({
+        providers: {
+          openai: { apiKey: 'test-key' },
+        },
+      });
+      const getInputMock = mock((name: string) => {
+        const inputs: Record<string, string> = {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          token: 'test-token',
+          thinking_level: '',
+          prompt: '',
+          pi_models_json: modelsJson,
+        };
+        return inputs[name];
+      });
+      mockCore.getInput = getInputMock as any;
+
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockPiFactory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelsJson,
+        }),
+        mockCore
+      );
+    });
+
+    test('omits modelsJson when input is empty', async () => {
+      const getInputMock = mock((name: string) => {
+        const inputs: Record<string, string> = {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          token: 'test-token',
+          thinking_level: '',
+          prompt: '',
+          pi_models_json: '',
+        };
+        return inputs[name];
+      });
+      mockCore.getInput = getInputMock as any;
+
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockPiFactory).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          modelsJson: expect.any(String),
+        }),
+        mockCore
+      );
+    });
+
+    test('calls getInput for pi_models_json', async () => {
+      const orchestrator = new ActionOrchestrator(mockCore, mockGithub, mockPiFactory);
+      await orchestrator.execute();
+
+      expect(mockCore.getInput).toHaveBeenCalledWith('pi_models_json');
     });
   });
 


### PR DESCRIPTION
## What

Adds a new `pi_models_json` action input (typically provided as a secret) that accepts the contents of `~/.pi/agent/models.json`, allowing users to define custom model configurations that override or merge with the built-in model registry.

## Why

The Pi SDK ships with a built-in model registry mapping provider/model combinations to their API endpoints. In some environments—enterprise proxies, OpenAI-compatible gateways, self-hosted model endpoints—the default model names or base URLs don't match what the registry provides. `pi_models_json` lets users:

- **Override base URLs** for existing providers (e.g., point `anthropic` models at an internal proxy)
- **Register custom model names** that map to non-standard endpoints (e.g., an OpenAI-compatible gateway with its own model IDs)
- **Add entirely new providers** not present in the built-in registry

This mirrors the same mechanism used in [`pi-action`](https://github.com/mcowger/pi-action), where `pi_models_json` is written to `~/.pi/agent/models.json` before `ModelRegistry.create()` loads built-in + custom models with custom winning on conflicts.

## How it works

1. User provides `pi_models_json` as an action input (typically `secrets.PI_MODELS_JSON`)
2. The orchestrator reads the input and passes it through `PiConfig.modelsJson`
3. The `Agent` constructor writes the JSON content to `~/.pi/agent/models.json` via `getAgentDir()`
4. `ModelRegistry.create(authStorage)` is used instead of `ModelRegistry.inMemory()`, which loads built-in models then merges/overrides with the custom definitions from `models.json`
5. When `pi_models_json` is empty/not provided, behavior is unchanged (`ModelRegistry.inMemory()`)

## Changes

- **`action.yml`**: Added `pi_models_json` input
- **`src/types.ts`**: Added `modelsJson?: string` to `PiConfig`
- **`src/orchestrator.ts`**: Gathers `pi_models_json` input in `gatherConfig()`
- **`src/pi/agent.ts`**: Accepts `modelsJson`, writes to disk, uses `ModelRegistry.create()` when provided
- **`src/adapters/pi-agent-adapter.ts`**: Passes `modelsJson` through to `Agent`
- **`tests/orchestrator.spec.ts`**: 3 new tests for `pi_models_json` configuration

## Testing

All 425 tests pass, including live E2E tests that exercise the real Pi SDK with valid credentials. New unit tests verify:

- `modelsJson` is passed to the Pi agent when provided
- `modelsJson` is omitted from config when input is empty
- `getInput(pi_models_json)` is called during config gathering