### PR TITLE
README.md: fix `|` char escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Create a workflow file, e.g., `.github/workflows/pi-agent.yml`. See the [interac
 | `model` | Model to use (e.g., gpt-5.4, gpt-4o, gemini-2.5-pro) | Yes | - |
 | `prompt` | Optional prompt to send to the agent (skips comment extraction) | No | - |
 | `provider` | LLM provider (openai, google, anthropic, etc.) | Yes | - |
-| `thinking_level` | Model thinking level (off|low|medium|high) | No | off |
+| `thinking_level` | Model thinking level (off\|low\|medium\|high) | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |
 | `trigger` | Trigger phrase used to invoke the action | No | /pi |
 


### PR DESCRIPTION
This cell of the table was not rendering properly in MarkDown.