### PR TITLE
docs(README.md): improve 'if' clause to detect /pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Dependencies (including Pi itself) are [updated regularly](./.github/workflows/d
 ### Interactive Workflows
 
 - Create a GitHub workflow which triggers when comments are added (e.g., `issue_comment`)
-- Filter by `if` to only run on the trigger phrase (e.g., `contains(github.event.comment.body, '/pi')`)
+- Filter by `if` to only run on the trigger phrase (e.g., `startsWith(github.event.comment.body, '/pi ')`)
 - Add `actions/setup-node` as prerequisite step (Node version >= `v22.x`)
 - Finally, add `shaftoe/pi-coding-agent-action`
 
@@ -105,7 +105,7 @@ permissions:
 
 jobs:
   pi-agent:
-    if: contains(github.event.comment.body, '/pi')
+    if: startsWith(github.event.comment.body, '/pi ')
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node


### PR DESCRIPTION
Everywhere in this README.md file where the "command" /pi is explained, the verb "prefix" is used. So then it is making the user think that the "bot" will only be activated when /pi is used at the **beginning** of a github comment if one follows the samples (i.e. in the Quick Start section).

Therefore, it is better to change these samples to use `startsWith` instead of `contains`. On top of that, to prevent the potential (although rare) collision with other possible commands that the user might have set up, or may set up in the future (e.g. "/pin yadda yadda", or simply "/ping", etc), it's safer to add a space after "/pi" in the string: "/pi ".

BTW, if you're skeptical of merging this PR, then let me tell you a little funny story that wouldn't have happened if this change had been done before I tried your project. (Note: it's funny now, and fortunately I was using a cheap model and a pay-as-you-go provider, and I noticed only 1h after it started happening; but imagine if this happens to someone that is using a frontier model, a provider that takes your credit card, and she goes to bed after the problem starts happening; unlike me that I just went to walk the dog and that's why I caught it only 1h after.)

The story begins when I tried to instruct Pi via /pi to create a PR that changed my pi.yml workflow to secure it by adding an `if github.actor = ...` element to it. That's when I filed #255, remember? After that, I then created a PAT and used it in my workflow, and then I instructed Pi via `/pi` to try to fix the issue again.

Then I decided to go walk my dog. And then when I came back, I found that, this time, it had been able to create PR, but the message to inform me about the work that had been done was written with my user account (because of the new PAT) and it contained the string /pi (because it was telling me that now only my github user can use the "/pi" command to trigger the workflow), so then that triggered another workflow, which itself created another PR and another message, which then spawned another workflow, and so on and so forth!

I fortunately only caught the infinite loop after 1h, and only about 2USD were spent (thanks cheap Kimi :pray:). I stopped it right away and it stopped creating PRs for the same thing again and again. So with this PR in place, I HTH to avoid this happening to anyone in the future.