### PR TITLE
feat(orchestrator): validate and clamp thinking_level against the resolved model

### DIFF
--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -174,10 +174,15 @@ export class Agent {
       const supported = getSupportedThinkingLevels(this.model);
       this.logger.warning(
         `[thinking] Requested level "${requestedThinkingLevel}" is not supported by ` +
-          `${this.config.provider}/${this.config.model}; clamping to "${effectiveThinkingLevel}" ` +
+          `${this.model.provider}/${this.model.id}; clamping to "${effectiveThinkingLevel}" ` +
           `(supported: ${supported.join(', ')})`
       );
       this.thinkingLevel = effectiveThinkingLevel;
+      // Propagate the effective level back to the config so that downstream
+      // consumers (e.g. the orchestrator's comment footer, which reads
+      // `config.thinkingLevel`) report the level actually in use rather than
+      // the originally-requested one.
+      this.config.thinkingLevel = effectiveThinkingLevel;
     }
 
     // Phase 2: Create the session with the resolved model.

--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -18,6 +18,7 @@ import {
   SessionManager,
   SettingsManager,
 } from '@earendil-works/pi-coding-agent';
+import { clampThinkingLevel, getSupportedThinkingLevels } from '@earendil-works/pi-ai';
 import { buildResourceLoaderOptions } from './resource-loader';
 import { getPiVersion } from '../version';
 
@@ -159,6 +160,24 @@ export class Agent {
           `Please check that the \`provider\` and \`model\` inputs are correct and that the provider is supported. ` +
           `See https://github.com/shaftoe/pi-coding-agent-action#usage for details.`
       );
+    }
+
+    // Clamp the requested thinking level to what the resolved model actually
+    // supports. This avoids passing an unsupported level (e.g. `xhigh` on a
+    // model that only goes to `high`) — or a genuinely invalid value from a
+    // misconfigured workflow input — straight to the provider. We degrade
+    // gracefully (clamp to the nearest supported level + warn) rather than
+    // throwing, since a level that one model doesn't support is not an error.
+    const requestedThinkingLevel = this.thinkingLevel;
+    const effectiveThinkingLevel = clampThinkingLevel(this.model, requestedThinkingLevel);
+    if (effectiveThinkingLevel !== requestedThinkingLevel) {
+      const supported = getSupportedThinkingLevels(this.model);
+      this.logger.warning(
+        `[thinking] Requested level "${requestedThinkingLevel}" is not supported by ` +
+          `${this.config.provider}/${this.config.model}; clamping to "${effectiveThinkingLevel}" ` +
+          `(supported: ${supported.join(', ')})`
+      );
+      this.thinkingLevel = effectiveThinkingLevel;
     }
 
     // Phase 2: Create the session with the resolved model.

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -39,6 +39,21 @@ function createCoreWithErrorCapture(): { core: any; messages: string[] } {
   return { core, messages };
 }
 
+/**
+ * Build a `CoreAdapter` whose `.warning(msg)` calls push `msg` into the returned
+ * array. Used to assert that thinking-level clamp warnings are surfaced.
+ */
+function createCoreWithWarningCapture(): { core: any; messages: string[] } {
+  const messages: string[] = [];
+  const core = {
+    ...mockCoreAdapter,
+    warning: mock((msg: string) => {
+      messages.push(msg);
+    }),
+  };
+  return { core, messages };
+}
+
 /** Default agent config used by most tests in this file. */
 const defaultAgentConfig = {
   model: 'claude-sonnet-4-5',
@@ -535,6 +550,72 @@ describe('Agent', () => {
 
       const result = await agent.ready();
       expect(result).toBe(agent);
+    });
+  });
+
+  describe('thinking level clamping', () => {
+    // claude-sonnet-4-5 supports off–high but NOT xhigh.
+    test('clamps unsupported xhigh to high and warns', async () => {
+      const { core: testCore, messages: warnings } = createCoreWithWarningCapture();
+
+      const agent = new Agent(testCore as any, mockPlatformProvider, {
+        ...defaultAgentConfig,
+        thinkingLevel: 'xhigh',
+      });
+
+      await agent.ready();
+
+      expect((agent as any).thinkingLevel).toBe('high');
+      const warning = warnings.find(m => m.startsWith('[thinking]'));
+      expect(warning).toBeDefined();
+      expect(warning).toContain('xhigh');
+      expect(warning).toContain('claude-sonnet-4-5');
+      expect(warning).toContain('high');
+      // The supported-levels list should exclude xhigh.
+      expect(warning).toContain('off, minimal, low, medium, high');
+    });
+
+    test('does not clamp a supported level (high)', async () => {
+      const { core: testCore, messages: warnings } = createCoreWithWarningCapture();
+
+      const agent = new Agent(testCore as any, mockPlatformProvider, {
+        ...defaultAgentConfig,
+        thinkingLevel: 'high',
+      });
+
+      await agent.ready();
+
+      expect((agent as any).thinkingLevel).toBe('high');
+      expect(warnings.find(m => m.startsWith('[thinking]'))).toBeUndefined();
+    });
+
+    test('does not clamp the default off level', async () => {
+      const { core: testCore, messages: warnings } = createCoreWithWarningCapture();
+
+      const agent = new Agent(testCore as any, mockPlatformProvider, {
+        ...defaultAgentConfig,
+        thinkingLevel: 'off',
+      });
+
+      await agent.ready();
+
+      expect((agent as any).thinkingLevel).toBe('off');
+      expect(warnings.find(m => m.startsWith('[thinking]'))).toBeUndefined();
+    });
+
+    test('normalizes invalid input (empty string) to off and warns', async () => {
+      const { core: testCore, messages: warnings } = createCoreWithWarningCapture();
+
+      const agent = new Agent(testCore as any, mockPlatformProvider, {
+        ...defaultAgentConfig,
+        thinkingLevel: '' as any,
+      });
+
+      await agent.ready();
+
+      expect((agent as any).thinkingLevel).toBe('off');
+      const warning = warnings.find(m => m.startsWith('[thinking]'));
+      expect(warning).toBeDefined();
     });
   });
 

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -566,6 +566,9 @@ describe('Agent', () => {
       await agent.ready();
 
       expect((agent as any).thinkingLevel).toBe('high');
+      // The effective level must also be propagated back to the config so the
+      // orchestrator's comment footer reports the level actually in use.
+      expect((agent as any).config.thinkingLevel).toBe('high');
       const warning = warnings.find(m => m.startsWith('[thinking]'));
       expect(warning).toBeDefined();
       expect(warning).toContain('xhigh');
@@ -614,8 +617,13 @@ describe('Agent', () => {
       await agent.ready();
 
       expect((agent as any).thinkingLevel).toBe('off');
+      // The effective level must also be propagated back to the config.
+      expect((agent as any).config.thinkingLevel).toBe('off');
       const warning = warnings.find(m => m.startsWith('[thinking]'));
       expect(warning).toBeDefined();
+      // For parity with the xhigh test, assert the normalized level surfaces
+      // in the warning message.
+      expect(warning).toContain('off');
     });
   });
 


### PR DESCRIPTION
## Summary

Extracts the thinking-level validation/clamping feature from #328 into its own focused PR (the sibling to #329 which carried the sync-script change). The agent previously blind-cast the user's `thinking_level` input and passed it straight to the provider with no model-awareness. It now clamps the level to what the resolved model actually supports and logs a warning when the effective level differs from what was requested.

## Changes

### `packages/pi-orchestrator/src/pi/agent.ts`

- **Import**: adds a value import of `clampThinkingLevel` / `getSupportedThinkingLevels` from `@earendil-works/pi-ai` (both are already available on the root entrypoint in the currently-pinned `0.79.10`, so this needs no dependency bump).
- **Clamp logic**: after the model is resolved in `ready()` (and before session creation), the requested `thinkingLevel` is run through `clampThinkingLevel()`. When the effective level differs, a `[thinking]` warning is logged naming the model, the requested level, the clamped level, and the full list of supported levels.

This mirrors the existing `loaded_tools` early-validation pattern, but as a **clamp + warn** (graceful degradation) rather than a hard error — a valid level that one model doesn't support is best resolved to the nearest supported level. `clampThinkingLevel()` picks the nearest supported level (e.g. `xhigh` → `high` for `claude-sonnet-4-5`). As a bonus it also normalizes genuinely invalid input (e.g. empty string → `off`) instead of passing garbage to the provider.

### `packages/pi-orchestrator/tests/pi/agent-logic.spec.ts`

Adds a `createCoreWithWarningCapture()` helper and 4 tests covering `claude-sonnet-4-5` (supports `off`–`high`, **not** `xhigh`):

- `xhigh` requested → clamped to `high`, warning logged with model name + supported-levels list
- `high` requested (supported) → unchanged, no warning
- default `off` → unchanged, no warning
- empty-string (invalid) → normalized to `off` with a warning

Each asserts both the effective level stored on the agent and the user-facing warning.

## Verification

- `bun run validate` (lint + tsc + prettier) ✅
- Full test suite: **1577 pass / 0 fail** (4 new) ✅
- `fallow dead-code`: no issues ✅
- No dependency version changes; no `dist/` changes (reverted the `prepare`-hook regeneration per repo convention)

Refs #328.