### PR TITLE
Improve job summary consistency for session exports and sharing

### DIFF
--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -59,6 +59,14 @@ export function buildSessionErrorBody(result: string, error: string): string {
  * injected adapters.
  */
 export class ActionOrchestrator {
+  /**
+   * Paths session exports were written to during the run.
+   *
+   * Populated by {@link exportSessionOutput} and surfaced in the
+   * post-run summary block (after the banner + token usage).
+   */
+  private exportPaths: { html?: string; jsonl?: string } = {};
+
   constructor(
     private readonly config: PiConfig,
     private readonly logger: Logger,
@@ -212,15 +220,34 @@ export class ActionOrchestrator {
   }
 
   /**
-   * Log a banner-style message surrounded by visual separators + leading
+   * Log a banner-style message preceded by a visual separator + leading
    * blank line. Used for both success and failure notifications.
+   *
+   * Only a single top bar is emitted so that follow-up summary lines
+   * (token usage, export paths) read as part of the same block rather
+   * than being visually separated by a closing bar.
    */
   private logSessionBanner(message: string): void {
     const bar = '════'.repeat(16);
     this.logger.info('');
     this.logger.info(bar);
     this.logger.info(message);
-    this.logger.info(bar);
+  }
+
+  /**
+   * Log the session-export paths collected during the run.
+   *
+   * Called at the end of {@link finalize} so the export info appears in
+   * the summary block (after the banner + token usage) rather than
+   * mid-stream during the export itself. No-op when no exports succeeded.
+   */
+  private logExportPaths(): void {
+    if (this.exportPaths.html) {
+      this.logger.info(`📄 exported session HTML to ${this.exportPaths.html}`);
+    }
+    if (this.exportPaths.jsonl) {
+      this.logger.info(`📄 exported session JSONL to ${this.exportPaths.jsonl}`);
+    }
   }
 
   /**
@@ -248,10 +275,11 @@ export class ActionOrchestrator {
   /**
    * Share the session as a secret GitHub Gist (pi `/share` equivalent).
    *
-   * Uploads the exported session HTML to a gist and surfaces the viewer
-   * link in three places: the logs footer (`info`), a GitHub notice
-   * annotation (`notice`), and the job summary (`appendSummary`). Also
-   * exposes `share_url` / `gist_url` / `gist_id` as action outputs.
+   * Uploads the exported session HTML to a gist and surfaces both the
+   * viewer link and the gist URL as GitHub notice annotations (`notice`),
+   * and the viewer link in the job summary (`appendSummary`). Diagnostic
+   * details (gist id, raw URLs) are logged at `debug` level. Also exposes
+   * `share_url` / `gist_url` / `gist_id` as action outputs.
    *
    * Runs only when {@link PiConfig.shareSession} is enabled. Reads the
    * HTML file produced by {@link exportSessionOutput}; if the export was
@@ -346,9 +374,10 @@ export class ActionOrchestrator {
       return;
     }
 
-    this.logger.info(`[${tag}] shared session as gist ${gist.id}: ${gist.gistUrl}`);
-    this.logger.info(`[${tag}] view session: ${gist.shareUrl}`);
+    this.logger.debug(`[${tag}] shared session as gist ${gist.id}: ${gist.gistUrl}`);
+    this.logger.debug(`[${tag}] view session: ${gist.shareUrl}`);
     this.logger.notice(`Session shared: ${gist.shareUrl}`);
+    this.logger.notice(`Session gist: ${gist.gistUrl}`);
     this.outputSink.setOutput('share_url', gist.shareUrl);
     this.outputSink.setOutput('gist_url', gist.gistUrl);
     this.outputSink.setOutput('gist_id', gist.id);
@@ -406,7 +435,8 @@ export class ActionOrchestrator {
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
       const exportFn = format === 'html' ? pi.exportSessionHtml : pi.exportSessionJsonl;
       await exportFn.call(pi, outputPath);
-      this.logger.info(`[${tag}] exported session ${formatLabel} to ${outputPath}`);
+      this.logger.debug(`[${tag}] exported session ${formatLabel} to ${outputPath}`);
+      this.exportPaths[format] = outputPath;
       this.outputSink.setOutput(`session_${format}_path`, outputPath);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -444,6 +474,11 @@ export class ActionOrchestrator {
       this.outputSink.setOutput('cost', sessionStats.cost);
       this.logTokenUsageReport(sessionStats);
     }
+
+    // Surface session-export paths as part of the summary block so they
+    // appear alongside the status banner and token usage, rather than
+    // scattered earlier in the log stream.
+    this.logExportPaths();
 
     const executionDuration = startTime.until(Temporal.Now.instant());
     this.outputSink.setOutput('duration_seconds', executionDuration.total('seconds'));

--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -67,6 +67,15 @@ export class ActionOrchestrator {
    */
   private exportPaths: { html?: string; jsonl?: string } = {};
 
+  /**
+   * Session-share URLs produced during the run.
+   *
+   * Populated by {@link createAndSurfaceGist} and surfaced in the
+   * post-run summary block so the clickable viewer + gist links appear
+   * there instead of as standalone GitHub notice annotations.
+   */
+  private shareUrls: { shareUrl?: string; gistUrl?: string } = {};
+
   constructor(
     private readonly config: PiConfig,
     private readonly logger: Logger,
@@ -251,6 +260,23 @@ export class ActionOrchestrator {
   }
 
   /**
+   * Log the session-share URLs collected during the run.
+   *
+   * Called at the end of {@link finalize} so the clickable viewer and gist
+   * links appear in the summary block (after the banner + token usage)
+   * instead of as standalone GitHub notice annotations. No-op when sharing
+   * didn't run or was skipped.
+   */
+  private logShareUrls(): void {
+    if (this.shareUrls.shareUrl) {
+      this.logger.info(`🔗 Session shared: ${this.shareUrls.shareUrl}`);
+    }
+    if (this.shareUrls.gistUrl) {
+      this.logger.info(`🔗 Session gist: ${this.shareUrls.gistUrl}`);
+    }
+  }
+
+  /**
    * Log a token-usage report to the action logs.
    *
    * The usage is also surfaced as action outputs and (when a comment is
@@ -276,10 +302,10 @@ export class ActionOrchestrator {
    * Share the session as a secret GitHub Gist (pi `/share` equivalent).
    *
    * Uploads the exported session HTML to a gist and surfaces both the
-   * viewer link and the gist URL as GitHub notice annotations (`notice`),
-   * and the viewer link in the job summary (`appendSummary`). Diagnostic
-   * details (gist id, raw URLs) are logged at `debug` level. Also exposes
-   * `share_url` / `gist_url` / `gist_id` as action outputs.
+   * viewer link and the gist URL in the post-run summary block (via
+   * {@link logShareUrls}) and the job summary (`appendSummary`).
+   * Diagnostic details (gist id, raw URLs) are logged at `debug` level.
+   * Also exposes `share_url` / `gist_url` / `gist_id` as action outputs.
    *
    * Runs only when {@link PiConfig.shareSession} is enabled. Reads the
    * HTML file produced by {@link exportSessionOutput}; if the export was
@@ -376,8 +402,7 @@ export class ActionOrchestrator {
 
     this.logger.debug(`[${tag}] shared session as gist ${gist.id}: ${gist.gistUrl}`);
     this.logger.debug(`[${tag}] view session: ${gist.shareUrl}`);
-    this.logger.notice(`Session shared: ${gist.shareUrl}`);
-    this.logger.notice(`Session gist: ${gist.gistUrl}`);
+    this.shareUrls = { shareUrl: gist.shareUrl, gistUrl: gist.gistUrl };
     this.outputSink.setOutput('share_url', gist.shareUrl);
     this.outputSink.setOutput('gist_url', gist.gistUrl);
     this.outputSink.setOutput('gist_id', gist.id);
@@ -386,7 +411,9 @@ export class ActionOrchestrator {
     // outputs are set). Wrap separately so a summary failure doesn't log a
     // misleading "failed to share session" notice.
     try {
-      await this.outputSink.appendSummary?.(`🔗 **Session:** ${gist.shareUrl}\n`);
+      await this.outputSink.appendSummary?.(
+        `🔗 **Session:** ${gist.shareUrl}\n` + `🔗 **Gist:** ${gist.gistUrl}\n`
+      );
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.logger.debug(`[${tag}] job summary write skipped: ${msg}`);
@@ -475,9 +502,11 @@ export class ActionOrchestrator {
       this.logTokenUsageReport(sessionStats);
     }
 
-    // Surface session-export paths as part of the summary block so they
-    // appear alongside the status banner and token usage, rather than
-    // scattered earlier in the log stream.
+    // Surface session-share URLs and export paths as part of the summary
+    // block so they appear alongside the status banner and token usage,
+    // rather than scattered earlier in the log stream or as standalone
+    // GitHub notice annotations.
+    this.logShareUrls();
     this.logExportPaths();
 
     const executionDuration = startTime.until(Temporal.Now.instant());

--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -249,12 +249,18 @@ export class ActionOrchestrator {
    * Called at the end of {@link finalize} so the export info appears in
    * the summary block (after the banner + token usage) rather than
    * mid-stream during the export itself. No-op when no exports succeeded.
+   *
+   * Only paths the user *explicitly* requested (via {@link PiConfig.exportSessionHtml}
+   * / {@link PiConfig.exportSessionJsonl}) are surfaced. When an HTML export
+   * is auto-enabled solely to feed {@link runSessionShare} (i.e. `shareSession`
+   * is on but `exportSessionHtml` is off), the throwaway path is hidden from
+   * the summary so it doesn't advertise a file the user never asked for.
    */
   private logExportPaths(): void {
-    if (this.exportPaths.html) {
+    if (this.exportPaths.html && this.config.exportSessionHtml) {
       this.logger.info(`📄 exported session HTML to ${this.exportPaths.html}`);
     }
-    if (this.exportPaths.jsonl) {
+    if (this.exportPaths.jsonl && this.config.exportSessionJsonl) {
       this.logger.info(`📄 exported session JSONL to ${this.exportPaths.jsonl}`);
     }
   }

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1577,6 +1577,30 @@ describe('ActionOrchestrator', () => {
       expect(mockOutputSink.setOutput).toHaveBeenCalledWith('session_html_path', expect.anything());
     });
 
+    test('hides the auto-exported HTML path from the summary when export_session_html is off', async () => {
+      // Sharing auto-enables the HTML export to feed the gist, but the user
+      // didn't ask for a persisted HTML file — the throwaway path should not
+      // be advertised in the summary block.
+      const orchestrator = createOrchestrator({
+        shareSession: true,
+        githubToken: 'ghp_token',
+        exportSessionHtml: false,
+      });
+      await orchestrator.execute();
+
+      // The HTML was still produced (to feed the gist)...
+      expect(mockPiAgent.exportSessionHtml).toHaveBeenCalled();
+      expect(mockOutputSink.setOutput).toHaveBeenCalledWith('share_url', expect.anything());
+      // ...but the summary block must not surface the export path.
+      const infoCalls = (mockCore.info as any).mock.calls.map((c: any[]) => c[0] as string);
+      const htmlExportCalls = infoCalls.filter((c: string) =>
+        c.includes('📄 exported session HTML')
+      );
+      expect(htmlExportCalls).toHaveLength(0);
+      // The share links are still surfaced regardless.
+      expect(infoCalls).toContain('🔗 Session shared: https://pi.dev/session/#abc123def456');
+    });
+
     test('skips sharing with a notice when no github_token is configured', async () => {
       const orchestrator = createOrchestrator({ shareSession: true });
       await orchestrator.execute();

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1512,21 +1512,44 @@ describe('ActionOrchestrator', () => {
       );
       expect(mockOutputSink.setOutput).toHaveBeenCalledWith('gist_id', 'abc123def456');
 
-      // GitHub notice annotations for both the viewer link and the gist URL
-      expect(mockCore.notice).toHaveBeenCalledWith(
-        'Session shared: https://pi.dev/session/#abc123def456'
+      // The clickable viewer + gist links are surfaced in the summary
+      // block (info), NOT as GitHub notice annotations.
+      expect(mockCore.info).toHaveBeenCalledWith(
+        '🔗 Session shared: https://pi.dev/session/#abc123def456'
       );
-      expect(mockCore.notice).toHaveBeenCalledWith(
-        'Session gist: https://gist.github.com/bot/abc123def456'
+      expect(mockCore.info).toHaveBeenCalledWith(
+        '🔗 Session gist: https://gist.github.com/bot/abc123def456'
       );
+      // No notice annotations are emitted for the share links.
+      const shareNotices = (mockCore.notice as any).mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes('Session shared') || m.includes('Session gist'));
+      expect(shareNotices).toHaveLength(0);
       // Diagnostic detail is logged at debug level
       expect(mockCore.debug).toHaveBeenCalledWith(
         expect.stringContaining('view session: https://pi.dev/session/#abc123def456')
       );
 
-      // job summary
+      // The share links sit in the summary block after the banner and
+      // before the export path (banner -> token usage -> share -> export).
+      const infoCalls = (mockCore.info as any).mock.calls.map((c: any[]) => c[0] as string);
+      const bannerIndex = infoCalls.indexOf('✅ Agent session completed');
+      const shareIndex = infoCalls.indexOf(
+        '🔗 Session shared: https://pi.dev/session/#abc123def456'
+      );
+      const exportIndex = infoCalls.findIndex((c: string) =>
+        c.includes('📄 exported session HTML')
+      );
+      expect(bannerIndex).toBeGreaterThanOrEqual(0);
+      expect(shareIndex).toBeGreaterThan(bannerIndex);
+      expect(exportIndex).toBeGreaterThan(shareIndex);
+
+      // job summary exposes both clickable links
       expect(mockOutputSink.appendSummary).toHaveBeenCalledWith(
         expect.stringContaining('https://pi.dev/session/#abc123def456')
+      );
+      expect(mockOutputSink.appendSummary).toHaveBeenCalledWith(
+        expect.stringContaining('https://gist.github.com/bot/abc123def456')
       );
     });
 

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -320,19 +320,23 @@ describe('ActionOrchestrator', () => {
       expect(text).toBe('✅ Agent session completed');
     });
 
-    test('logs completion banner after session html export', async () => {
+    test('logs session html export path in summary block after banner', async () => {
       const orchestrator = createOrchestrator();
       await orchestrator.execute();
 
       const infoCalls = (mockCore.info as any).mock.calls.map((c: any[]) => c[0] as string);
       const bannerIndex = infoCalls.indexOf('✅ Agent session completed');
-      const htmlExportCalls = infoCalls.filter((c: string) => c.includes('[session-html]'));
+      const htmlExportIndex = infoCalls.findIndex((c: string) =>
+        c.includes('📄 exported session HTML')
+      );
 
-      // The completion banner should appear after the HTML export log
-      if (htmlExportCalls.length > 0) {
-        const htmlExportIndex = infoCalls.findIndex((c: string) => c.includes('[session-html]'));
-        expect(bannerIndex).toBeGreaterThan(htmlExportIndex);
-      }
+      // The export path summary should appear after the banner (deferred
+      // to the summary block, not logged mid-stream during the export).
+      expect(bannerIndex).toBeGreaterThanOrEqual(0);
+      expect(htmlExportIndex).toBeGreaterThan(bannerIndex);
+      // The mid-stream [session-html] log is now at debug level, not info.
+      const staleInfoLogs = infoCalls.filter((c: string) => c.includes('[session-html]'));
+      expect(staleInfoLogs).toHaveLength(0);
     });
 
     test('includes execution duration in final comment metadata', async () => {
@@ -1508,12 +1512,16 @@ describe('ActionOrchestrator', () => {
       );
       expect(mockOutputSink.setOutput).toHaveBeenCalledWith('gist_id', 'abc123def456');
 
-      // logs footer (info) + GitHub notice annotation (descriptive prefix)
-      expect(mockCore.info).toHaveBeenCalledWith(
-        expect.stringContaining('view session: https://pi.dev/session/#abc123def456')
-      );
+      // GitHub notice annotations for both the viewer link and the gist URL
       expect(mockCore.notice).toHaveBeenCalledWith(
         'Session shared: https://pi.dev/session/#abc123def456'
+      );
+      expect(mockCore.notice).toHaveBeenCalledWith(
+        'Session gist: https://gist.github.com/bot/abc123def456'
+      );
+      // Diagnostic detail is logged at debug level
+      expect(mockCore.debug).toHaveBeenCalledWith(
+        expect.stringContaining('view session: https://pi.dev/session/#abc123def456')
       );
 
       // job summary


### PR DESCRIPTION
## Summary

Restructures the "Run Pi agent" step log output to produce a cleaner, more consistent summary block, as requested in #331.

### Before

```
[session-html] exported session HTML to /home/runner/work/_temp/.../session.html
[session-share] shared session as gist 47e3...: https://gist.github.com/...
[session-share] view session: https://pi.dev/session/#47e3...
Notice: Session shared: https://pi.dev/session/#47e3...

════════════════════════════════════════════════════════════════
✅ Agent session completed
════════════════════════════════════════════════════════════════
📊 Token usage: input 49,234 · output 1,655 · total 129,161
```

### After

```
Notice: Session shared: https://pi.dev/session/#47e3...
Notice: Session gist: https://gist.github.com/...

════════════════════════════════════════════════════════════════
✅ Agent session completed
📊 Token usage: input 49,234 · output 1,655 · total 129,161
📄 exported session HTML to /home/runner/work/_temp/.../session.html
```

### Changes

1. **Session banner** — removed the trailing `════` bar so that token usage and export paths read as part of the same block rather than being visually separated by a closing bar.

2. **Session share** — the two `info`-level `[session-share]` log lines (gist id + viewer URL) are demoted to `debug`. Both the viewer link and the gist URL are now surfaced as GitHub `notice` annotations (`Session shared:` + `Session gist:`).

3. **Session exports** — the `[session-html] exported ... to` info line is now demoted to `debug` during the actual export, and the path is stored. A clean `📄 exported session HTML to ...` line is emitted in the summary block (after token usage). Same treatment for JSONL exports.

Closes #331