### PR TITLE
docs: note Forgejo compatibility has been confirmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ Refer to [the official Pi documentation](https://pi.dev/docs/latest) to learn ho
 ## Disclaimer
 
 > [!NOTE]
-> Codeberg/Forgejo compatibility _should_ work but hasn't been tested yet.
+> Codeberg/Forgejo compatibility has been confirmed on self-hosted **Forgejo** instances, where the action runs the Pi agent as expected (at least in non-interactive mode). Not every feature has been exercised yet on these platforms — PRs documenting additional coverage are welcome.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Updates the README disclaimer to reflect that Codeberg/Forgejo compatibility is no longer just "should work but hasn't been tested" — it has now been confirmed working on a self-hosted **Forgejo** instance (at least in non-interactive mode).

Closes #334.

## Context

As reported in #334, the action has been successfully run on a Forgejo + Actions runner setup (see the linked run). The README previously carried a disclaimer stating compatibility "_should_ work but hasn't been tested yet", which is now outdated. This keeps the note honest about coverage (non-interactive mode confirmed; not every feature exercised yet) while inviting further coverage reports.

## Changes

- `README.md` — updated the "Disclaimer" `> [!NOTE]` block.

```diff
-> Codeberg/Forgejo compatibility _should_ work but hasn't been tested yet.
+> Codeberg/Forgejo compatibility has been confirmed on self-hosted **Forgejo** instances, where the action runs the Pi agent as expected (at least in non-interactive mode). Not every feature has been exercised yet on these platforms — PRs documenting additional coverage are welcome.
```

## Notes

- Docs-only change; no code or behaviour impact.
- `bun run validate` could not be run in this environment (the `eslint` binary isn't installed on the runner), but the change introduces no formatting issues (verified the Prettier diff only flags pre-existing table formatting elsewhere in the README).