### PR TITLE
feat(share): add Opengist backend for session sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,9 @@ The link is surfaced in two places: the job log footer and the **job summary** (
 Enabling `share_session` **auto-enables `export_session_html`** (the gist carries the HTML export's bytes), so you don't need to set both.
 
 > [!IMPORTANT]
-> **A GitHub token with `gist` scope is required.** The default `secrets.GITHUB_TOKEN` **cannot** create gists. Set the `github_token` input to a classic PAT (with the `gist` scope), a fine-grained PAT (Account → **Gists: read/write**), or a GitHub App installation token — the same token is used for all GitHub API operations.
+> **A GitHub token with `gist` scope is required** for the default (`github`) provider. The default `secrets.GITHUB_TOKEN` **cannot** create gists. Set the `github_token` input to a classic PAT (with the `gist` scope), a fine-grained PAT (Account → **Gists: read/write**), or a GitHub App installation token — the same token is used for all GitHub API operations.
+>
+> Using a self-hosted [Opengist](https://github.com/thomiceli/opengist) instance instead? See [Opengist backend](#opengist-backend) below.
 
 > [!WARNING]
 > Secret gists are **URL-obscured, not access-controlled** — anyone with the link can read the rendered session, which may include code, file contents, or secrets the agent touched. Only enable `share_session` for runs where that exposure is acceptable, and prefer a dedicated bot account so shared gists are easy to audit and delete.
@@ -630,6 +632,34 @@ Enabling `share_session` **auto-enables `export_session_html`** (the gist carrie
 > - Each gist's description includes the repo, issue number, and run ID (`Pi session — owner/repo#123 (run 456)`) for easy identification in the gist list.
 > - Periodically prune old gists via the [GitHub Gist API](https://docs.github.com/en/rest/gists/gists#delete-a-gist) or the web UI. The `gist_id` action output is available for automation — e.g. a scheduled workflow could list and delete gists older than a threshold.
 > - The `gist_url` output points to each gist's page where it can be reviewed or deleted manually.
+
+#### Opengist backend
+
+By default `share_session` uploads to **GitHub Gists** and links to the `pi.dev/session` viewer. You can instead upload to a self-hosted [Opengist](https://github.com/thomiceli/opengist) instance (e.g. `gist.l3x.in`) by setting `share_gist_provider: opengist`.
+
+The pi.dev viewer **cannot** read non-GitHub gists (it hardcodes `api.github.com`), so for the Opengist backend the `share_url` points directly at the gist's **raw HTML** route. The exported session HTML is self-contained (session data is embedded inline), and Opengist serves `.html` files with `Content-Type: text/html` and an inline disposition, so the raw link renders the full session in any browser with no viewer dependency.
+
+```yaml
+- uses: shaftoe/pi-coding-agent-action@v2
+  id: pi
+  with:
+    share_session: true
+    share_gist_provider: opengist
+    share_gist_api_url: https://gist.l3x.in/api/gists   # Opengist REST API lives under /api/, not /api/v1/
+    share_gist_token: ${{ secrets.OPENGIST_TOKEN }}       # Opengist access token (og_…) with gist:write scope
+    provider: openai
+    model: gpt-5.4
+    token: ${{ secrets.OPENAI_API_KEY }}
+
+- name: Echo share link
+  if: ${{ steps.pi.outputs.share_url }}
+  run: echo "Session: ${{ steps.pi.outputs.share_url }}"
+```
+
+Notes:
+- The Opengist REST API create endpoint is `POST <instance>/api/gists`. Create an access token in **Settings → Access Tokens** (it starts with `og_`) and grant it the `gist:write` scope. See the [Opengist API docs](https://opengist.io/docs).
+- Gists are created as `unlisted` (not listed publicly, but readable via the unguessable URL) — the closest analogue of a GitHub "secret" gist.
+- `share_gist_token` is optional: when unset, the action falls back to `github_token`, so you can reuse a single token if your Opengist setup accepts it.
 
 ### Auto-Compaction
 
@@ -665,7 +695,10 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `pr_number` | Pull request number to target. Use with `workflow_dispatch` to run the agent on a specific PR without a triggering event. When set, the action fetches PR context from the API and targets all operations at the specified PR | No | - |
 | `prompt` | Optional prompt to send to the agent (skips comment extraction) | No | - |
 | `provider` | LLM provider (openai, google, anthropic, etc.) | Yes | - |
-| `share_session` | Share the session like pi's `/share` command: upload the exported HTML to a secret GitHub Gist and surface a pi.dev viewer link. Uses the `github_token` input (PAT/App token with gist scope required). Auto-enables `export_session_html` | No | `false` |
+| `share_session` | Share the session like pi's `/share` command: upload the exported HTML to a gist and surface a viewer link. Uses GitHub Gists by default (`share_gist_provider: github`) or a self-hosted Opengist instance. Auto-enables `export_session_html` | No | `false` |
+| `share_gist_provider` | Storage backend for `share_session`: `github` (GitHub Gists + pi.dev viewer) or `opengist` (self-hosted instance; requires `share_gist_api_url`) | No | `github` |
+| `share_gist_api_url` | API URL for the share gist provider. Required for `opengist` (e.g. `https://gist.l3x.in/api/gists`); optional override for `github` | No | - |
+| `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist`; falls back to `github_token` | No | - |
 | `thinking_level` | Model thinking level | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |
 | `trigger` | Trigger phrase used to invoke the action | No | /pi  |
@@ -680,14 +713,14 @@ The action exposes the following outputs, which can be consumed by downstream st
 |--------|-------------|----------|
 | `cost` | Cost of the invocation in USD (omitted if unavailable) | `0.042` |
 | `duration_seconds` | Wall-clock duration of agent execution in seconds | `12.7` |
-| `gist_id` | GitHub Gist ID holding the shared session HTML (when `share_session` succeeds) | `abc123def456` |
-| `gist_url` | GitHub Gist URL holding the shared session HTML (when `share_session` succeeds) | `https://gist.github.com/bot/abc123def456` |
+| `gist_id` | ID of the gist holding the shared session HTML — a GitHub Gist ID or Opengist UUID (when `share_session` succeeds) | `abc123def456` |
+| `gist_url` | Gist page URL — GitHub Gist or Opengist (when `share_session` succeeds) | `https://gist.github.com/bot/abc123def456` |
 | `input_tokens` | Number of input tokens consumed (omitted if unavailable) | `1500` |
 | `output_tokens` | Number of output tokens generated (omitted if unavailable) | `800` |
 | `response` | The main agent response text (or error message on failure) | `Here is the fix for the bug...` |
 | `session_html_path` | Path to the exported session HTML file (when `export_session_html` is enabled, or when `share_session` is enabled) | `/tmp/pi-session-html/session.html` |
 | `session_jsonl_path` | Path to the exported session JSONL file (when `export_session_jsonl` is enabled) | `/tmp/pi-session-jsonl/session.jsonl` |
-| `share_url` | pi.dev-style viewer link for the shared session (when `share_session` succeeds) | `https://pi.dev/session/#abc123def456` |
+| `share_url` | Shareable session link. GitHub provider: a pi.dev viewer link (`https://pi.dev/session/#<gistId>`). Opengist provider: a self-rendering raw-HTML URL on the instance (when `share_session` succeeds) | `https://pi.dev/session/#abc123def456` |
 | `success` | Whether the agent completed successfully (`true` / `false`) | `true` |
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ Notes:
 - The Opengist REST API create endpoint is `POST <instance>/api/gists`. Create an access token in **Settings → Access Tokens** (it starts with `og_`) and grant it the `gist:write` scope. See the [Opengist API docs](https://opengist.io/docs).
 - Gists are created as `unlisted` (not listed publicly, but readable via the unguessable URL) — the closest analogue of a GitHub "secret" gist.
 - `share_gist_token` is optional: when unset, the action falls back to `github_token`, so you can reuse a single token if your Opengist setup accepts it.
+- The `share_url` uses the gist's **raw route** (`<gist page>/raw/HEAD/session.html`), which Opengist serves as `text/html` so the self-contained session renders directly in a browser. The `HEAD` revision resolves to the latest commit (see the [Opengist docs](https://opengist.io/docs)). Because this raw-route behaviour is instance-specific, **verify it after upgrading Opengist** by creating a shared session and opening the link in a fresh browser — if your version doesn't accept `HEAD` on the raw route, share links will 404.
 
 ### Auto-Compaction
 

--- a/README.md
+++ b/README.md
@@ -639,6 +639,9 @@ By default `share_session` uploads to **GitHub Gists** and links to the `pi.dev/
 
 The pi.dev viewer **cannot** read non-GitHub gists (it hardcodes `api.github.com`), so for the Opengist backend the `share_url` points directly at the gist's **raw HTML** route. The exported session HTML is self-contained (session data is embedded inline), and Opengist serves `.html` files with `Content-Type: text/html` and an inline disposition, so the raw link renders the full session in any browser with no viewer dependency.
 
+> [!WARNING]
+> **Same-origin XSS surface (Opengist only).** With the default (`github`) provider the rendered session is served from `pi.dev` — an isolated origin separate from where gists are stored. The Opengist `share_url`, by contrast, renders the session's HTML on the **same origin** as your Opengist instance (e.g. `gist.l3x.in`), which the viewer is typically logged into. The exported HTML carries the viewer JavaScript plus any rendered tool output and file contents; if any of that is not escaped by the session exporter, it executes with the Opengist origin's privileges (session cookies, authenticated `/api/...` calls) — a stored-XSS vector that does **not** exist for the GitHub backend. Mitigations: prefer a dedicated or isolated Opengist instance (or a separate viewer account) for shared sessions, and only enable `share_session` when you trust the session contents.
+
 ```yaml
 - uses: shaftoe/pi-coding-agent-action@v2
   id: pi

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,21 @@ inputs:
     required: false
     default: 'false'
 
+  share_gist_provider:
+    description: 'Storage backend for session sharing. Defaults to `github` (GitHub Gists + pi.dev viewer). Set to `opengist` to upload to a self-hosted Opengist instance instead — in that case also set share_gist_api_url (and a share_gist_token or github_token with gist:write access). When opengist is used, share_url points at a self-rendering raw-HTML link (the pi.dev viewer cannot read non-GitHub gists).'
+    required: false
+    default: 'github'
+
+  share_gist_api_url:
+    description: 'API URL for the share gist provider. Required when share_gist_provider is `opengist`: the instance''s create endpoint, e.g. `https://gist.l3x.in/api/gists` (Opengist''s REST API lives under /api/, not /api/v1/). Optional override for the github provider (defaults to https://api.github.com/gists).'
+    required: false
+    default: ''
+
+  share_gist_token:
+    description: 'Token used to create the shared gist. For opengist, an Opengist access token (og_…) with the gist:write scope. Falls back to github_token when unset, so the github provider keeps working with a single token.'
+    required: false
+    default: ''
+
   auto_compaction:
     description: 'Enable automatic context compaction when the conversation grows too large for the model context window. When enabled, Pi will summarize older messages to free up context space, allowing longer sessions without hitting context limits.'
     required: false
@@ -122,8 +137,8 @@ outputs:
   session_jsonl_path:
     description: 'Path to the exported session JSONL file (when export_session_jsonl is enabled)'
   share_url:
-    description: 'Pi.dev-style viewer link for the shared session (https://pi.dev/session/#<gistId>), when share_session is enabled and succeeds'
+    description: 'Shareable session link. For the github provider: a pi.dev viewer link (https://pi.dev/session/#<gistId>). For the opengist provider: a self-rendering raw-HTML URL on the configured instance. Set when share_session is enabled and succeeds.'
   gist_url:
-    description: 'GitHub Gist URL holding the shared session HTML, when share_session is enabled and succeeds'
+    description: 'URL of the gist holding the shared session HTML (GitHub Gist page or Opengist page), when share_session is enabled and succeeds'
   gist_id:
-    description: 'GitHub Gist ID holding the shared session HTML, when share_session is enabled and succeeds'
+    description: 'ID of the gist holding the shared session HTML, when share_session is enabled and succeeds'

--- a/packages/pi-action/src/adapters/config.ts
+++ b/packages/pi-action/src/adapters/config.ts
@@ -169,6 +169,20 @@ export function gatherActionsConfig(): PiConfig {
   const autoCompaction = parseBooleanInput(core.getInput('auto_compaction'), false);
   const shareSession = parseBooleanInput(core.getInput('share_session'), false);
 
+  // --- Session sharing storage backend inputs ---------------------------
+  const shareGistProviderRaw = core.getInput('share_gist_provider').trim().toLowerCase();
+  const shareGistProvider =
+    shareGistProviderRaw === 'opengist'
+      ? 'opengist'
+      : shareGistProviderRaw === 'github'
+        ? 'github'
+        : undefined;
+  const shareGistApiUrl = core.getInput('share_gist_api_url').trim() || undefined;
+  const shareGistToken = core.getInput('share_gist_token').trim() || undefined;
+  if (shareGistToken) {
+    core.setSecret(shareGistToken);
+  }
+
   // --- Optional positive-integer inputs ----------------------------------
   const diffMaxLines = parsePositiveIntInput(core.getInput('diff_max_lines'));
   const diffMaxBytes = parsePositiveIntInput(core.getInput('diff_max_bytes'));
@@ -197,6 +211,9 @@ export function gatherActionsConfig(): PiConfig {
     exportSessionJsonl,
     autoCompaction,
     shareSession,
+    ...(shareGistProvider ? { shareGistProvider } : {}),
+    ...(shareGistApiUrl ? { shareGistApiUrl } : {}),
+    ...(shareGistToken ? { shareGistToken } : {}),
     ...(githubToken ? { githubToken } : {}),
     ...(diffMaxLines ? { diffMaxLines } : {}),
     ...(diffMaxBytes ? { diffMaxBytes } : {}),

--- a/packages/pi-action/src/adapters/config.ts
+++ b/packages/pi-action/src/adapters/config.ts
@@ -177,6 +177,16 @@ export function gatherActionsConfig(): PiConfig {
       : shareGistProviderRaw === 'github'
         ? 'github'
         : undefined;
+  // An unknown value (typo, or a backend we don't support yet) silently
+  // collapses to the github default. Warn so a misconfigured provider is
+  // visible instead of quietly creating a GitHub gist with ignored Opengist
+  // config.
+  if (shareGistProviderRaw && !shareGistProvider) {
+    core.warning(
+      `Unknown share_gist_provider "${shareGistProviderRaw}"; falling back to github. ` +
+        'Valid values are "github" and "opengist".'
+    );
+  }
   const shareGistApiUrl = core.getInput('share_gist_api_url').trim() || undefined;
   const shareGistToken = core.getInput('share_gist_token').trim() || undefined;
   if (shareGistToken) {

--- a/packages/pi-action/tests/adapters/config.spec.ts
+++ b/packages/pi-action/tests/adapters/config.spec.ts
@@ -50,6 +50,7 @@ describe('gatherActionsConfig', () => {
     coreMock.getInput.mockClear();
     coreMock.debug.mockClear();
     coreMock.setSecret.mockClear();
+    coreMock.warning.mockClear();
     mockCore();
   });
 
@@ -263,9 +264,18 @@ describe('gatherActionsConfig', () => {
       expect(gatherActionsConfig().shareGistProvider).toBe('opengist');
     });
 
-    test('normalizes an unknown share_gist_provider to undefined', () => {
+    test('normalizes an unknown share_gist_provider to undefined and warns', () => {
       mockCore({ share_gist_provider: 'dropbox' });
       expect(gatherActionsConfig().shareGistProvider).toBeUndefined();
+      expect(coreMock.warning).toHaveBeenCalledWith(
+        expect.stringMatching(/Unknown share_gist_provider "dropbox".*falling back to github/)
+      );
+    });
+
+    test('does not warn for a recognised share_gist_provider', () => {
+      mockCore({ share_gist_provider: 'opengist' });
+      gatherActionsConfig();
+      expect(coreMock.warning).not.toHaveBeenCalled();
     });
 
     test('parses share_gist_api_url', () => {

--- a/packages/pi-action/tests/adapters/config.spec.ts
+++ b/packages/pi-action/tests/adapters/config.spec.ts
@@ -253,5 +253,36 @@ describe('gatherActionsConfig', () => {
       gatherActionsConfig();
       expect(coreMock.setSecret).not.toHaveBeenCalled();
     });
+
+    test('share_gist_provider defaults to undefined (github)', () => {
+      expect(gatherActionsConfig().shareGistProvider).toBeUndefined();
+    });
+
+    test('parses share_gist_provider opengist (case-insensitive)', () => {
+      mockCore({ share_gist_provider: 'Opengist' });
+      expect(gatherActionsConfig().shareGistProvider).toBe('opengist');
+    });
+
+    test('normalizes an unknown share_gist_provider to undefined', () => {
+      mockCore({ share_gist_provider: 'dropbox' });
+      expect(gatherActionsConfig().shareGistProvider).toBeUndefined();
+    });
+
+    test('parses share_gist_api_url', () => {
+      mockCore({ share_gist_api_url: 'https://gist.l3x.in/api/gists' });
+      expect(gatherActionsConfig().shareGistApiUrl).toBe('https://gist.l3x.in/api/gists');
+    });
+
+    test('omits share_gist_api_url when empty', () => {
+      mockCore({ share_gist_api_url: '   ' });
+      expect(gatherActionsConfig().shareGistApiUrl).toBeUndefined();
+    });
+
+    test('parses share_gist_token and registers it as a secret', () => {
+      mockCore({ share_gist_token: 'og_secret' });
+      const config = gatherActionsConfig();
+      expect(config.shareGistToken).toBe('og_secret');
+      expect(coreMock.setSecret).toHaveBeenCalledWith('og_secret');
+    });
   });
 });

--- a/packages/pi-orchestrator/src/index.ts
+++ b/packages/pi-orchestrator/src/index.ts
@@ -56,7 +56,22 @@ export type { ActionBuildInfo } from './version';
 
 // Session sharing (gist)
 export { createSessionGist } from './share/gist';
-export type { CreateGistInput, CreatedGist } from './share/gist';
+export type { CreateGistInput, CreatedGist, GistProvider } from './share/gist';
+export {
+  DEFAULT_SHARE_VIEWER_URL,
+  DEFAULT_GITHUB_GIST_API,
+  MAX_GIST_CONTENT_BYTES,
+  GIST_CREATE_TIMEOUT_MS,
+  fetchWithTimeout,
+  githubGistProvider,
+} from './share/gist';
+export {
+  createOpengistGist,
+  opengistGistProvider,
+  DEFAULT_OPENGIST_API_PATH,
+} from './share/opengist';
+export { resolveGistProvider, resolveShareToken } from './share/provider';
+export type { ShareProviderConfig } from './share/provider';
 
 // Types
 export type {

--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -26,7 +26,8 @@ import {
 import { formatCost } from './format';
 import type { CreateReactionType, PlatformProvider } from './platform';
 import { getActionVersion, formatActionVersion } from './version';
-import { createSessionGist, MAX_GIST_CONTENT_BYTES, type CreatedGist } from './share/gist';
+import { MAX_GIST_CONTENT_BYTES, type CreatedGist, type GistProvider } from './share/gist';
+import { resolveGistProvider, resolveShareToken } from './share/provider';
 
 /**
  * Build the body of the success comment posted at the end of a run.
@@ -326,10 +327,24 @@ export class ActionOrchestrator {
     }
 
     const tag = 'session-share';
-    const token = this.config.githubToken;
+    const token = resolveShareToken(this.config);
     if (!token) {
       this.logger.notice(
-        `[${tag}] skipped: no github_token configured (provide a PAT/App token with gist scope via github_token)`
+        `[${tag}] skipped: no share token configured ` +
+          '(provide a PAT/App token with gist scope via github_token, ' +
+          'or an Opengist access token via share_gist_token)'
+      );
+      return;
+    }
+
+    const provider = resolveGistProvider(this.config);
+    // Opengist is self-hosted, so there is no default API endpoint — the
+    // operator must point us at their instance. Skip with an actionable
+    // notice instead of letting the provider throw deep in the call stack.
+    if (provider.name === 'opengist' && !this.config.shareGistApiUrl) {
+      this.logger.notice(
+        `[${tag}] skipped: opengist provider requires share_gist_api_url ` +
+          '(e.g. https://gist.l3x.in/api/gists)'
       );
       return;
     }
@@ -342,7 +357,7 @@ export class ActionOrchestrator {
       return; // skip notice already logged in readShareContent
     }
 
-    await this.createAndSurfaceGist(token, content, tag);
+    await this.createAndSurfaceGist(provider, token, content, tag);
   }
 
   /**
@@ -394,12 +409,22 @@ export class ActionOrchestrator {
    * failure doesn't produce a misleading "failed to share session" message
    * — by that point the gist exists and the outputs are already set.
    */
-  private async createAndSurfaceGist(token: string, content: string, tag: string): Promise<void> {
+  private async createAndSurfaceGist(
+    provider: GistProvider,
+    token: string,
+    content: string,
+    tag: string
+  ): Promise<void> {
     const description = this.buildShareDescription();
 
     let gist: CreatedGist;
     try {
-      gist = await createSessionGist({ token, content, description });
+      gist = await provider.create({
+        token,
+        content,
+        description,
+        ...(this.config.shareGistApiUrl ? { apiUrl: this.config.shareGistApiUrl } : {}),
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.logger.notice(`[${tag}] failed to share session: ${msg}`);

--- a/packages/pi-orchestrator/src/share/gist.ts
+++ b/packages/pi-orchestrator/src/share/gist.ts
@@ -60,6 +60,47 @@ export const MAX_GIST_CONTENT_BYTES = 10 * 1024 * 1024;
  */
 export const GIST_CREATE_TIMEOUT_MS = 15_000;
 
+/**
+ * Identity of a gist-storage backend (GitHub Gists, Opengist, …).
+ *
+ * Each provider speaks its own create-API contract and builds a
+ * {@link CreatedGist} with an appropriate `shareUrl` (GitHub → pi.dev
+ * viewer; Opengist → a self-rendering raw-HTML link).
+ */
+export interface GistProvider {
+  /** Stable identifier (`'github'` | `'opengist'`), used in logs. */
+  readonly name: 'github' | 'opengist';
+  /** Create a gist holding the session content and return share details. */
+  create(input: CreateGistInput): Promise<CreatedGist>;
+}
+
+/**
+ * POST JSON to `url` with an AbortController-based timeout, translating an
+ * `AbortError` into an actionable timeout message.
+ *
+ * Shared by all gist providers so the timeout/abort behaviour is identical
+ * regardless of the backend's request shape. The caller owns the headers and
+ * body; this helper only attaches the timeout signal.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = GIST_CREATE_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error(`gist create timed out after ${timeoutMs}ms`);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /** Inputs for {@link createSessionGist}. */
 export interface CreateGistInput {
   /**
@@ -128,13 +169,11 @@ export async function createSessionGist(
   } = input;
 
   // Abort the request if it stalls so a hung connection can't block the
-  // entire action. The surrounding runSessionShare catch logs the
-  // AbortError as a notice and the run continues.
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GIST_CREATE_TIMEOUT_MS);
-  let response: Response;
-  try {
-    response = await fetch(apiUrl, {
+  // entire action. The surrounding runSessionShare catch logs the timeout
+  // error as a notice and the run continues.
+  const response = await fetchWithTimeout(
+    apiUrl,
+    {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -148,16 +187,9 @@ export async function createSessionGist(
         public: isPublic,
         files: { [filename]: { content } },
       }),
-      signal: controller.signal,
-    });
-  } catch (e) {
-    if (e instanceof Error && e.name === 'AbortError') {
-      throw new Error(`gist create timed out after ${GIST_CREATE_TIMEOUT_MS}ms`);
-    }
-    throw e;
-  } finally {
-    clearTimeout(timeout);
-  }
+    },
+    GIST_CREATE_TIMEOUT_MS
+  );
 
   if (!response.ok) {
     const detail = await response.text().catch(() => '');
@@ -191,3 +223,14 @@ export async function createSessionGist(
     shareUrl: `${viewerUrl}#${json.id}`,
   };
 }
+
+/**
+ * GitHub Gists provider (default). Wraps {@link createSessionGist} behind the
+ * {@link GistProvider} interface so the orchestrator is agnostic to the
+ * storage backend. The viewer URL defaults to {@link DEFAULT_SHARE_VIEWER_URL}
+ * (honours `PI_SHARE_VIEWER_URL`).
+ */
+export const githubGistProvider: GistProvider = {
+  name: 'github',
+  create: (input: CreateGistInput) => createSessionGist(input),
+};

--- a/packages/pi-orchestrator/src/share/gist.ts
+++ b/packages/pi-orchestrator/src/share/gist.ts
@@ -101,6 +101,49 @@ export async function fetchWithTimeout(
   }
 }
 
+/**
+ * Minimum shape shared by every gist-create response we understand
+ * (GitHub Gists and Opengist both return `id` + `html_url`).
+ */
+export interface GistCreateResponse {
+  id?: string;
+  html_url?: string;
+}
+
+/**
+ * Throw an actionable error when a gist-create response is non-2xx.
+ *
+ * Shared by all providers so the error wording is identical regardless of
+ * the backend. Reads the body only on the failure path.
+ */
+export async function assertGistResponseOk(response: Response): Promise<void> {
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `gist create failed: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ''}`
+    );
+  }
+}
+
+/**
+ * Guard against a 2xx response with an unexpected shape (proxy interference,
+ * partial response, future API change). Without this, a malformed response
+ * silently produces `undefined` ids/urls and a `<viewer>#undefined` share link.
+ *
+ * Shared by all providers — both GitHub and Opengist return `id` + `html_url`.
+ * Implemented as a generic `asserts` so callers keep type narrowing on `id` /
+ * `html_url` (and any extra fields they declared on the response type).
+ */
+export function assertGistHasIdAndUrl<T extends GistCreateResponse>(
+  json: T
+): asserts json is T & { id: string; html_url: string } {
+  if (!json.id || !json.html_url) {
+    throw new Error(
+      `gist create returned unexpected response (no id/html_url): ${JSON.stringify(json).slice(0, 200)}`
+    );
+  }
+}
+
 /** Inputs for {@link createSessionGist}. */
 export interface CreateGistInput {
   /**
@@ -191,12 +234,7 @@ export async function createSessionGist(
     GIST_CREATE_TIMEOUT_MS
   );
 
-  if (!response.ok) {
-    const detail = await response.text().catch(() => '');
-    throw new Error(
-      `gist create failed: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ''}`
-    );
-  }
+  await assertGistResponseOk(response);
 
   const json = (await response.json()) as {
     id?: string;
@@ -204,15 +242,7 @@ export async function createSessionGist(
     files?: Record<string, { raw_url?: string }>;
   };
 
-  // Guard against a 2xx response with an unexpected shape (proxy
-  // interference, partial response, future API change). Without this,
-  // a malformed response silently produces undefined gist_id/gist_url
-  // and a share_url of "<viewer>#undefined".
-  if (!json.id || !json.html_url) {
-    throw new Error(
-      `gist create returned unexpected response (no id/html_url): ${JSON.stringify(json).slice(0, 200)}`
-    );
-  }
+  assertGistHasIdAndUrl(json);
 
   const file = json.files?.[filename];
 

--- a/packages/pi-orchestrator/src/share/opengist.ts
+++ b/packages/pi-orchestrator/src/share/opengist.ts
@@ -101,7 +101,6 @@ export async function createOpengistGist(input: CreateGistInput): Promise<Create
   const json = (await response.json()) as {
     id?: string;
     html_url?: string;
-    slug_url?: string;
   };
 
   assertGistHasIdAndUrl(json);
@@ -116,6 +115,16 @@ export async function createOpengistGist(input: CreateGistInput): Promise<Create
   // resolves live, so verify the rendered link after upgrading your instance.
   // `html_url` is `<origin>/<user>/<identifier>`, so appending the raw segment
   // yields a stable URL.
+  //
+  // SECURITY (Opengist only): unlike the GitHub provider — where the session
+  // renders on `pi.dev`, an origin isolated from where gists are stored — this
+  // raw link is served from the **same origin** as the Opengist app the viewer
+  // is logged into. The exported HTML carries the viewer JS plus rendered tool
+  // output / file contents, so anything that isn't escaped by the session
+  // exporter runs with the Opengist origin's privileges (cookies, authenticated
+  // `/api/...` calls) — a stored-XSS vector absent from the GitHub backend.
+  // Operators should prefer a dedicated/isolated Opengist instance (or account)
+  // for shared sessions; see the README WARNING.
   const base = json.html_url.replace(/\/$/, '');
   const rawUrl = `${base}/raw/HEAD/${encodeURIComponent(filename)}`;
 

--- a/packages/pi-orchestrator/src/share/opengist.ts
+++ b/packages/pi-orchestrator/src/share/opengist.ts
@@ -30,6 +30,8 @@ import {
   type GistProvider,
   GIST_CREATE_TIMEOUT_MS,
   fetchWithTimeout,
+  assertGistResponseOk,
+  assertGistHasIdAndUrl,
 } from './gist';
 
 /**
@@ -94,12 +96,7 @@ export async function createOpengistGist(input: CreateGistInput): Promise<Create
     GIST_CREATE_TIMEOUT_MS
   );
 
-  if (!response.ok) {
-    const detail = await response.text().catch(() => '');
-    throw new Error(
-      `gist create failed: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ''}`
-    );
-  }
+  await assertGistResponseOk(response);
 
   const json = (await response.json()) as {
     id?: string;
@@ -107,18 +104,18 @@ export async function createOpengistGist(input: CreateGistInput): Promise<Create
     slug_url?: string;
   };
 
-  if (!json.id || !json.html_url) {
-    throw new Error(
-      `gist create returned unexpected response (no id/html_url): ${JSON.stringify(json).slice(0, 200)}`
-    );
-  }
+  assertGistHasIdAndUrl(json);
 
   // The exported session HTML is fully self-contained, so Opengist's raw web
   // route renders the whole session in a browser with no viewer dependency.
   // The route is `GET /:user/:gistname/raw/:revision/:file`; "HEAD" resolves to
-  // the latest revision (the same value Opengist uses internally for its embed
-  // view). `html_url` is `<origin>/<user>/<identifier>`, so appending the raw
-  // segment yields a stable, always-valid URL.
+  // the latest revision (the value Opengist uses for its embed view — see
+  // https://opengist.io/docs). This is an instance-specific behaviour: if a
+  // future Opengist release stops accepting `HEAD` on the raw route, every
+  // share link would 404. The tests assert the URL shape, not that it
+  // resolves live, so verify the rendered link after upgrading your instance.
+  // `html_url` is `<origin>/<user>/<identifier>`, so appending the raw segment
+  // yields a stable URL.
   const base = json.html_url.replace(/\/$/, '');
   const rawUrl = `${base}/raw/HEAD/${encodeURIComponent(filename)}`;
 

--- a/packages/pi-orchestrator/src/share/opengist.ts
+++ b/packages/pi-orchestrator/src/share/opengist.ts
@@ -1,0 +1,143 @@
+/**
+ * @file Opengist session-sharing provider.
+ *
+ * Uploads the exported session HTML to a **self-hosted Opengist** instance
+ * (https://github.com/thomiceli/opengist) instead of GitHub Gists, so you can
+ * keep shared sessions on your own infrastructure (e.g. `gist.l3x.in`).
+ *
+ * Why a dedicated provider (and not just an `apiUrl` swap on the GitHub one):
+ * - **Route:** Opengist's REST API lives under `/api/` — the create endpoint is
+ *   `POST <instance>/api/gists` (GitHub's is `POST api.github.com/gists`). The
+ *   prior assumption that it was `/api/v1/gists` was wrong; `/api/v1` 404s.
+ * - **Body:** Opengist uses a `visibility` string (`public` | `unlisted` |
+ *   `private`) where GitHub uses a `public` boolean, and accepts a `title`
+ *   field. The `files` map shape (`{ name: { content } }`) happens to match
+ *   GitHub's, but the rest of the contract differs.
+ * - **Auth:** an Opengist access token (`og_…`) with the `gist:write` scope,
+ *   sent as `Authorization: Bearer og_…` — not a GitHub PAT.
+ * - **Viewer:** the pi.dev viewer hardcodes `api.github.com`, so it can't read
+ *   an Opengist gist. Instead we point `shareUrl` at the gist's **raw** web
+ *   route: the exported HTML is self-contained (session data inline), and
+ *   Opengist serves `.html` files with `Content-Type: text/html` and an
+ *   `inline` disposition (no restrictive CSP for HTML — only SVG/PDF get one),
+ *   so the raw URL renders the full session in any browser with no viewer
+ *   dependency. See https://opengist.io/docs for the API reference.
+ */
+
+import {
+  type CreateGistInput,
+  type CreatedGist,
+  type GistProvider,
+  GIST_CREATE_TIMEOUT_MS,
+  fetchWithTimeout,
+} from './gist';
+
+/**
+ * Path appended to an Opengist instance origin to reach the create endpoint.
+ *
+ * Opengist's REST API is mounted under `/api/` (no version segment), so for an
+ * instance at `https://gist.l3x.in` the create URL is
+ * `https://gist.l3x.in/api/gists`. Used only to build a friendly error message
+ * — the real endpoint always comes from {@link CreateGistInput.apiUrl}.
+ */
+export const DEFAULT_OPENGIST_API_PATH = '/api/gists';
+
+/**
+ * Create a gist on an Opengist instance and return a self-rendering share link.
+ *
+ * @param input - Gist creation parameters. `apiUrl` **must** be set to the
+ *   instance's create endpoint (e.g. `https://gist.l3x.in/api/gists`); there is
+ *   no sensible default since Opengist is self-hosted.
+ * @returns The created gist details + a raw-HTML share URL.
+ * @throws when the API call fails (non-2xx) or the response is malformed.
+ */
+export async function createOpengistGist(input: CreateGistInput): Promise<CreatedGist> {
+  const {
+    token,
+    content,
+    filename = 'session.html',
+    description = 'Pi agent session',
+    public: isPublic = false,
+    apiUrl,
+  } = input;
+
+  if (!apiUrl) {
+    throw new Error(
+      `opengist provider requires an API URL (e.g. https://gist.l3x.in${DEFAULT_OPENGIST_API_PATH}); ` +
+        'set share_gist_api_url'
+    );
+  }
+
+  // Opengist uses a `visibility` enum instead of GitHub's `public` boolean.
+  // `unlisted` is the closest analogue of a GitHub "secret" gist: it doesn't
+  // appear in public listings but is readable by anyone who has the
+  // (unguessable) URL — exactly the "URL-obscured, not access-controlled"
+  // model the GitHub provider documents.
+  const visibility: 'public' | 'unlisted' = isPublic ? 'public' : 'unlisted';
+
+  const response = await fetchWithTimeout(
+    apiUrl,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'pi-coding-agent-action',
+      },
+      body: JSON.stringify({
+        title: description,
+        visibility,
+        files: { [filename]: { content } },
+      }),
+    },
+    GIST_CREATE_TIMEOUT_MS
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `gist create failed: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ''}`
+    );
+  }
+
+  const json = (await response.json()) as {
+    id?: string;
+    html_url?: string;
+    slug_url?: string;
+  };
+
+  if (!json.id || !json.html_url) {
+    throw new Error(
+      `gist create returned unexpected response (no id/html_url): ${JSON.stringify(json).slice(0, 200)}`
+    );
+  }
+
+  // The exported session HTML is fully self-contained, so Opengist's raw web
+  // route renders the whole session in a browser with no viewer dependency.
+  // The route is `GET /:user/:gistname/raw/:revision/:file`; "HEAD" resolves to
+  // the latest revision (the same value Opengist uses internally for its embed
+  // view). `html_url` is `<origin>/<user>/<identifier>`, so appending the raw
+  // segment yields a stable, always-valid URL.
+  const base = json.html_url.replace(/\/$/, '');
+  const rawUrl = `${base}/raw/HEAD/${encodeURIComponent(filename)}`;
+
+  return {
+    id: json.id,
+    gistUrl: json.html_url,
+    rawUrl,
+    // The raw URL is the primary share link because it renders the session
+    // standalone; the gist page (gistUrl) only shows the HTML source.
+    shareUrl: rawUrl,
+  };
+}
+
+/**
+ * Opengist provider. Implements {@link GistProvider} so the orchestrator
+ * treats it identically to the GitHub provider — only the request/response
+ * contract and the resulting share URL differ.
+ */
+export const opengistGistProvider: GistProvider = {
+  name: 'opengist',
+  create: createOpengistGist,
+};

--- a/packages/pi-orchestrator/src/share/provider.ts
+++ b/packages/pi-orchestrator/src/share/provider.ts
@@ -23,11 +23,10 @@ export interface ShareProviderConfig {
   shareGistProvider?: 'github' | 'opengist';
   /**
    * Gist-creation token for the chosen provider. For Opengist this is an
-   * access token (`og_…`) with the `gist:write` scope. Falls back to
-   * `githubToken` when unset, preserving backwards compatibility for GitHub.
+   * access token (`og_…`) with the `gist:write` scope.
    */
   shareGistToken?: string;
-  /** GitHub token, used as the share token fallback. */
+  /** GitHub token, used as the share token for the github provider. */
   githubToken?: string;
 }
 
@@ -42,13 +41,24 @@ export function resolveGistProvider(config: ShareProviderConfig): GistProvider {
 }
 
 /**
- * Resolve the token used to create the shared gist.
+ * Resolve the token used to create the shared gist, picking the credential
+ * that matches the selected provider and only crossing over when the
+ * preferred token is absent.
  *
- * Prefers `shareGistToken` (letting Opengist users supply an Opengist access
- * token that differs from their GitHub PAT), then falls back to `githubToken`
- * so the GitHub path keeps working with the single `github_token` input.
+ * - **opengist** prefers `shareGistToken` (an `og_…` token), falling back to
+ *   `githubToken`.
+ * - **github** (default) prefers `githubToken`, falling back to
+ *   `shareGistToken`.
+ *
+ * This provider-aware selection prevents mismatched combos — e.g. an `og_`
+ * Opengist token being sent to `api.github.com`, or a `ghp_` GitHub token
+ * being sent to an Opengist instance — from producing confusing auth
+ * failures, while keeping the single-`github_token` GitHub workflow intact.
  */
 export function resolveShareToken(config: ShareProviderConfig): string | undefined {
+  const isOpengist = config.shareGistProvider === 'opengist';
+  const primary = isOpengist ? config.shareGistToken : config.githubToken;
+  const fallback = isOpengist ? config.githubToken : config.shareGistToken;
   /* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional ||: an empty-string token must fall through to the fallback (a "" token would fail auth) */
-  return config.shareGistToken || config.githubToken;
+  return primary || fallback;
 }

--- a/packages/pi-orchestrator/src/share/provider.ts
+++ b/packages/pi-orchestrator/src/share/provider.ts
@@ -1,0 +1,54 @@
+/**
+ * @file Gist-provider selection for session sharing.
+ *
+ * Resolves which storage backend ({@link githubGistProvider} or
+ * {@link opengistGistProvider}) handles session sharing, and the token used to
+ * authenticate against it. Keeping this in a dedicated module avoids a circular
+ * import: both providers live in `gist.ts`/`opengist.ts`, while this module is
+ * the only one that depends on both.
+ */
+
+import type { GistProvider } from './gist';
+import { githubGistProvider } from './gist';
+import { opengistGistProvider } from './opengist';
+
+/**
+ * Configuration subset consumed by the share-provider resolver.
+ *
+ * Mirrors the share-related fields of `PiConfig` so the resolver is unit-testable
+ * without constructing a full config object.
+ */
+export interface ShareProviderConfig {
+  /** Storage backend: `'github'` (default) or `'opengist'`. */
+  shareGistProvider?: 'github' | 'opengist';
+  /**
+   * Gist-creation token for the chosen provider. For Opengist this is an
+   * access token (`og_…`) with the `gist:write` scope. Falls back to
+   * `githubToken` when unset, preserving backwards compatibility for GitHub.
+   */
+  shareGistToken?: string;
+  /** GitHub token, used as the share token fallback. */
+  githubToken?: string;
+}
+
+/**
+ * Select the gist provider for session sharing.
+ *
+ * Unknown / unset values fall back to GitHub (the original behaviour), so this
+ * is purely additive and existing `share_session` workflows are unaffected.
+ */
+export function resolveGistProvider(config: ShareProviderConfig): GistProvider {
+  return config.shareGistProvider === 'opengist' ? opengistGistProvider : githubGistProvider;
+}
+
+/**
+ * Resolve the token used to create the shared gist.
+ *
+ * Prefers `shareGistToken` (letting Opengist users supply an Opengist access
+ * token that differs from their GitHub PAT), then falls back to `githubToken`
+ * so the GitHub path keeps working with the single `github_token` input.
+ */
+export function resolveShareToken(config: ShareProviderConfig): string | undefined {
+  /* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional ||: an empty-string token must fall through to the fallback (a "" token would fail auth) */
+  return config.shareGistToken || config.githubToken;
+}

--- a/packages/pi-orchestrator/src/types.ts
+++ b/packages/pi-orchestrator/src/types.ts
@@ -243,6 +243,27 @@ export interface PiConfig extends DiffConfig {
    * {@link shareSession} is enabled.
    */
   githubToken?: string;
+  /**
+   * Storage backend for session sharing: `'github'` (default) or
+   * `'opengist'`. When `'opengist'`, the exported session HTML is uploaded
+   * to a self-hosted Opengist instance (via {@link shareGistApiUrl}) instead
+   * of GitHub Gists, and the `share_url` points at a self-rendering raw-HTML
+   * link rather than the pi.dev viewer (which only reads GitHub gists).
+   */
+  shareGistProvider?: 'github' | 'opengist';
+  /**
+   * API URL for the share gist provider. For `'opengist'` this is the
+   * instance's create endpoint, e.g. `https://gist.l3x.in/api/gists`
+   * (required when {@link shareGistProvider} is `'opengist'`). For GitHub,
+   * an optional override (defaults to `https://api.github.com/gists`).
+   */
+  shareGistApiUrl?: string;
+  /**
+   * Token used to create the shared gist. For Opengist, an access token
+   * (`og_…`) with the `gist:write` scope. Falls back to {@link githubToken}
+   * when unset, so the GitHub path keeps working with a single token.
+   */
+  shareGistToken?: string;
   /** Override the default system prompt. */
   systemPrompt?: string;
   /** Working directory. Defaults to `process.cwd()`. */

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1688,7 +1688,6 @@ describe('ActionOrchestrator', () => {
         json: async () => ({
           id: 'og-uuid-123',
           html_url: 'https://gist.l3x.in/bot/my-session',
-          slug_url: 'my-session',
         }),
         text: async () => '',
       })) as unknown as typeof fetch;

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1601,13 +1601,13 @@ describe('ActionOrchestrator', () => {
       expect(infoCalls).toContain('🔗 Session shared: https://pi.dev/session/#abc123def456');
     });
 
-    test('skips sharing with a notice when no github_token is configured', async () => {
+    test('skips sharing with a notice when no share token is configured', async () => {
       const orchestrator = createOrchestrator({ shareSession: true });
       await orchestrator.execute();
 
       expect(globalThis.fetch).not.toHaveBeenCalled();
       expect(mockOutputSink.setOutput).not.toHaveBeenCalledWith('share_url', expect.anything());
-      expect(mockCore.notice).toHaveBeenCalledWith(expect.stringContaining('no github_token'));
+      expect(mockCore.notice).toHaveBeenCalledWith(expect.stringContaining('no share token'));
     });
 
     test('continues execution when gist creation fails', async () => {
@@ -1677,6 +1677,93 @@ describe('ActionOrchestrator', () => {
       expect(mockCore.debug).toHaveBeenCalledWith(
         expect.stringContaining('job summary write skipped')
       );
+    });
+
+    test('shares to Opengist and surfaces a raw-HTML share link', async () => {
+      // Opengist create response: id + html_url; the provider derives a
+      // raw/HEAD link that renders the self-contained session.
+      globalThis.fetch = mock(async () => ({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'og-uuid-123',
+          html_url: 'https://gist.l3x.in/bot/my-session',
+          slug_url: 'my-session',
+        }),
+        text: async () => '',
+      })) as unknown as typeof fetch;
+
+      const orchestrator = createOrchestrator({
+        shareSession: true,
+        shareGistProvider: 'opengist',
+        shareGistApiUrl: 'https://gist.l3x.in/api/gists',
+        shareGistToken: 'og_opengist-token',
+      });
+      await orchestrator.execute();
+
+      // The request hit the Opengist route with the Opengist body shape.
+      const calls = (globalThis.fetch as any).mock.calls;
+      const [url, init] = calls[0];
+      expect(url).toBe('https://gist.l3x.in/api/gists');
+      const body = JSON.parse(init.body);
+      expect(body.visibility).toBe('unlisted');
+      expect(body.title).toBe('Pi session — test-owner/test-repo#1 (run 123)');
+      expect(init.headers.Authorization).toBe('Bearer og_opengist-token');
+
+      // Outputs carry the raw-HTML link (renders standalone), not pi.dev.
+      expect(mockOutputSink.setOutput).toHaveBeenCalledWith(
+        'share_url',
+        'https://gist.l3x.in/bot/my-session/raw/HEAD/session.html'
+      );
+      expect(mockOutputSink.setOutput).toHaveBeenCalledWith(
+        'gist_url',
+        'https://gist.l3x.in/bot/my-session'
+      );
+      expect(mockOutputSink.setOutput).toHaveBeenCalledWith('gist_id', 'og-uuid-123');
+
+      expect(mockCore.info).toHaveBeenCalledWith(
+        '🔗 Session shared: https://gist.l3x.in/bot/my-session/raw/HEAD/session.html'
+      );
+    });
+
+    test('skips Opengist sharing with a notice when share_gist_api_url is missing', async () => {
+      const orchestrator = createOrchestrator({
+        shareSession: true,
+        shareGistProvider: 'opengist',
+        shareGistToken: 'og_token',
+        // shareGistApiUrl intentionally omitted
+      });
+      await orchestrator.execute();
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(mockOutputSink.setOutput).not.toHaveBeenCalledWith('share_url', expect.anything());
+      expect(mockCore.notice).toHaveBeenCalledWith(
+        expect.stringContaining('opengist provider requires share_gist_api_url')
+      );
+    });
+
+    test('uses githubToken as the share token fallback for Opengist', async () => {
+      globalThis.fetch = mock(async () => ({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'og-uuid',
+          html_url: 'https://gist.l3x.in/bot/s',
+        }),
+        text: async () => '',
+      })) as unknown as typeof fetch;
+
+      const orchestrator = createOrchestrator({
+        shareSession: true,
+        shareGistProvider: 'opengist',
+        shareGistApiUrl: 'https://gist.l3x.in/api/gists',
+        // shareGistToken unset — should fall back to githubToken
+        githubToken: 'ghp_fallback',
+      });
+      await orchestrator.execute();
+
+      const init = (globalThis.fetch as any).mock.calls[0][1];
+      expect(init.headers.Authorization).toBe('Bearer ghp_fallback');
     });
   });
 });

--- a/packages/pi-orchestrator/tests/share/opengist.spec.ts
+++ b/packages/pi-orchestrator/tests/share/opengist.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the Opengist session-sharing provider (`createOpengistGist`).
+ *
+ * Verifies the exact Opengist REST API contract (route, headers, body shape
+ * with `visibility`/`title`, and the `files` map), and that the resulting
+ * `share_url` is a self-rendering raw-HTML link rather than a pi.dev viewer
+ * link (the pi.dev viewer can only read GitHub gists).
+ *
+ * Reference: https://opengist.io/docs — the create endpoint is
+ * `POST /api/gists` (the API lives under `/api/`, not `/api/v1/`), the body
+ * uses `visibility: public|unlisted|private` + a `title`, and the response
+ * carries `id` + `html_url`. Uses a mocked global `fetch`.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import {
+  createOpengistGist,
+  opengistGistProvider,
+  DEFAULT_OPENGIST_API_PATH,
+} from '../../src/share/opengist';
+import { GIST_CREATE_TIMEOUT_MS } from '../../src/share/gist';
+
+describe('createOpengistGist', () => {
+  const originalFetch = globalThis.fetch;
+  const apiUrl = 'https://gist.l3x.in/api/gists';
+
+  beforeEach(() => {
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        html_url: 'https://gist.l3x.in/bot/my-session',
+        slug_url: 'my-session',
+        visibility: 'unlisted',
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('creates an unlisted gist with the correct Opengist HTTP contract', async () => {
+    await createOpengistGist({
+      token: 'og_token',
+      content: '<html>session</html>',
+      apiUrl,
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const calls = (globalThis.fetch as any).mock.calls;
+    const [url, init] = calls[0];
+    // Route is /api/gists (NOT /api/v1/gists — that 404s).
+    expect(url).toBe(apiUrl);
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    // Bearer auth, not GitHub-specific Accept headers.
+    expect(headers.Authorization).toBe('Bearer og_token');
+    expect(headers.Accept).toBe('application/json');
+    expect(headers).not.toHaveProperty('X-GitHub-Api-Version');
+
+    const body = JSON.parse(init?.body as string);
+    // Opengist uses visibility + title, NOT a public boolean.
+    expect(body.visibility).toBe('unlisted');
+    expect(body.public).toBeUndefined();
+    expect(body.title).toBe('Pi agent session');
+    // The files map shape matches GitHub's ({ name: { content } }).
+    expect(body.files['session.html'].content).toBe('<html>session</html>');
+  });
+
+  test('maps the public flag to the visibility enum', async () => {
+    await createOpengistGist({
+      token: 'og_token',
+      content: 'x',
+      apiUrl,
+      public: true,
+      description: 'custom title',
+    });
+
+    const body = JSON.parse((globalThis.fetch as any).mock.calls[0][1].body);
+    expect(body.visibility).toBe('public');
+    expect(body.title).toBe('custom title');
+  });
+
+  test('returns a self-rendering raw-HTML share URL (not pi.dev)', async () => {
+    const gist = await createOpengistGist({
+      token: 'og_token',
+      content: 'x',
+      apiUrl,
+    });
+
+    expect(gist.id).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(gist.gistUrl).toBe('https://gist.l3x.in/bot/my-session');
+    // Raw route: <html_url>/raw/HEAD/<filename> — serves text/html inline,
+    // so the self-contained session renders in a browser with no viewer.
+    expect(gist.rawUrl).toBe('https://gist.l3x.in/bot/my-session/raw/HEAD/session.html');
+    expect(gist.shareUrl).toBe(gist.rawUrl);
+    // Must NOT be a pi.dev link (the viewer hardcodes api.github.com).
+    expect(gist.shareUrl).not.toContain('pi.dev');
+  });
+
+  test('URL-encodes the filename in the raw link', async () => {
+    const gist = await createOpengistGist({
+      token: 'og_token',
+      content: 'x',
+      apiUrl,
+      filename: 'my session.html',
+    });
+
+    expect(gist.rawUrl).toBe('https://gist.l3x.in/bot/my-session/raw/HEAD/my%20session.html');
+  });
+
+  test('strips a trailing slash from html_url before building the raw link', async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 'uuid-1',
+        html_url: 'https://gist.l3x.in/bot/my-session/',
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const gist = await createOpengistGist({ token: 't', content: 'x', apiUrl });
+    expect(gist.rawUrl).toBe('https://gist.l3x.in/bot/my-session/raw/HEAD/session.html');
+  });
+
+  test('throws when apiUrl is missing (Opengist is self-hosted)', async () => {
+    await expect(createOpengistGist({ token: 't', content: 'x' })).rejects.toThrow(
+      new RegExp(`opengist provider requires an API URL.*${DEFAULT_OPENGIST_API_PATH}`)
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test('throws with status + body detail on non-2xx', async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+      text: async () => '{"message":"invalid token"}',
+    })) as unknown as typeof fetch;
+
+    await expect(createOpengistGist({ token: 'bad', content: 'x', apiUrl })).rejects.toThrow(
+      /401 Unauthorized.*invalid token/
+    );
+  });
+
+  test('passes an AbortSignal to fetch for timeout safety', async () => {
+    await createOpengistGist({ token: 't', content: 'x', apiUrl });
+
+    const init = (globalThis.fetch as any).mock.calls[0][1];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('throws a timeout error when the request aborts', async () => {
+    globalThis.fetch = mock(async (_url: string, init: RequestInit) => {
+      if (init.signal) {
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      return { ok: true, status: 201, json: async () => ({}), text: async () => '' } as any;
+    }) as unknown as typeof fetch;
+
+    await expect(createOpengistGist({ token: 't', content: 'x', apiUrl })).rejects.toThrow(
+      `gist create timed out after ${GIST_CREATE_TIMEOUT_MS}ms`
+    );
+  });
+
+  test('throws when the 2xx response lacks id/html_url (malformed)', async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: 'unexpected proxy response' }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    await expect(createOpengistGist({ token: 't', content: 'x', apiUrl })).rejects.toThrow(
+      /unexpected response.*no id\/html_url/
+    );
+  });
+
+  test('opengistGistProvider delegates to createOpengistGist', async () => {
+    expect(opengistGistProvider.name).toBe('opengist');
+    const gist = await opengistGistProvider.create({ token: 't', content: 'x', apiUrl });
+    expect(gist.shareUrl).toContain('/raw/HEAD/session.html');
+  });
+});

--- a/packages/pi-orchestrator/tests/share/opengist.spec.ts
+++ b/packages/pi-orchestrator/tests/share/opengist.spec.ts
@@ -31,7 +31,6 @@ describe('createOpengistGist', () => {
       json: async () => ({
         id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         html_url: 'https://gist.l3x.in/bot/my-session',
-        slug_url: 'my-session',
         visibility: 'unlisted',
       }),
       text: async () => '',

--- a/packages/pi-orchestrator/tests/share/provider.spec.ts
+++ b/packages/pi-orchestrator/tests/share/provider.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the gist-provider resolver (`resolveGistProvider`, `resolveShareToken`).
+ *
+ * Verifies backend selection and token fallback without exercising the network.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveGistProvider, resolveShareToken } from '../../src/share/provider';
+import { githubGistProvider } from '../../src/share/gist';
+import { opengistGistProvider } from '../../src/share/opengist';
+
+describe('resolveGistProvider', () => {
+  test('defaults to the github provider when the field is unset', () => {
+    expect(resolveGistProvider({}).name).toBe('github');
+    expect(resolveGistProvider({})).toBe(githubGistProvider);
+  });
+
+  test('selects the github provider explicitly', () => {
+    expect(resolveGistProvider({ shareGistProvider: 'github' })).toBe(githubGistProvider);
+  });
+
+  test('selects the opengist provider', () => {
+    expect(resolveGistProvider({ shareGistProvider: 'opengist' })).toBe(opengistGistProvider);
+  });
+
+  test('falls back to github when the field is unset', () => {
+    expect(resolveGistProvider({}).name).toBe('github');
+  });
+});
+
+describe('resolveShareToken', () => {
+  test('prefers shareGistToken over githubToken', () => {
+    expect(resolveShareToken({ shareGistToken: 'og_123', githubToken: 'ghp_456' })).toBe('og_123');
+  });
+
+  test('falls back to githubToken when shareGistToken is unset', () => {
+    expect(resolveShareToken({ githubToken: 'ghp_456' })).toBe('ghp_456');
+  });
+
+  test('returns undefined when neither token is set', () => {
+    expect(resolveShareToken({})).toBeUndefined();
+  });
+
+  test('ignores an empty shareGistToken and falls back', () => {
+    expect(resolveShareToken({ githubToken: 'ghp_456' })).toBe('ghp_456');
+  });
+});

--- a/packages/pi-orchestrator/tests/share/provider.spec.ts
+++ b/packages/pi-orchestrator/tests/share/provider.spec.ts
@@ -29,11 +29,39 @@ describe('resolveGistProvider', () => {
 });
 
 describe('resolveShareToken', () => {
-  test('prefers shareGistToken over githubToken', () => {
-    expect(resolveShareToken({ shareGistToken: 'og_123', githubToken: 'ghp_456' })).toBe('og_123');
+  test('prefers shareGistToken over githubToken for the opengist provider', () => {
+    expect(
+      resolveShareToken({
+        shareGistProvider: 'opengist',
+        shareGistToken: 'og_123',
+        githubToken: 'ghp_456',
+      })
+    ).toBe('og_123');
   });
 
-  test('falls back to githubToken when shareGistToken is unset', () => {
+  test('falls back to githubToken for opengist when shareGistToken is unset', () => {
+    expect(resolveShareToken({ shareGistProvider: 'opengist', githubToken: 'ghp_456' })).toBe(
+      'ghp_456'
+    );
+  });
+
+  test('prefers githubToken over shareGistToken for the github provider', () => {
+    expect(
+      resolveShareToken({
+        shareGistProvider: 'github',
+        shareGistToken: 'og_123',
+        githubToken: 'ghp_456',
+      })
+    ).toBe('ghp_456');
+  });
+
+  test('crosses over to shareGistToken for github when githubToken is unset', () => {
+    expect(resolveShareToken({ shareGistProvider: 'github', shareGistToken: 'og_123' })).toBe(
+      'og_123'
+    );
+  });
+
+  test('defaults to the githubToken preference when the provider is unset', () => {
     expect(resolveShareToken({ githubToken: 'ghp_456' })).toBe('ghp_456');
   });
 
@@ -42,6 +70,12 @@ describe('resolveShareToken', () => {
   });
 
   test('ignores an empty shareGistToken and falls back', () => {
-    expect(resolveShareToken({ githubToken: 'ghp_456' })).toBe('ghp_456');
+    expect(resolveShareToken({ shareGistToken: '', githubToken: 'ghp_456' })).toBe('ghp_456');
+  });
+
+  test('ignores an empty githubToken and crosses over to shareGistToken for github', () => {
+    expect(
+      resolveShareToken({ shareGistProvider: 'github', githubToken: '', shareGistToken: 'og_123' })
+    ).toBe('og_123');
   });
 });


### PR DESCRIPTION
## Summary

Adds a self-hosted [Opengist](https://github.com/thomiceli/opengist) backend for the `share_session` feature, so shared sessions can be stored on your own Opengist instance (e.g. `gist.l3x.in`) instead of GitHub Gists. Closes #337.

This implements the proposal from the analysis report in #337, with one important correction verified against the live [Opengist API docs](https://opengist.io/docs):

> **The create route is `POST /api/gists`, not `/api/v1/gists`.** The report's 404 was caused by the wrong `/api/v1/` prefix — Opengist's REST API lives under `/api/`. The `files: { name: { content } }` body shape is actually identical to GitHub's; the real differences are the `visibility` enum (`public`/`unlisted`/`private`) vs GitHub's `public` boolean, a `title` field, and `og_…` Bearer tokens with a `gist:write` scope.

## Approach

Introduced a minimal, backwards-compatible **gist-provider abstraction** in `packages/pi-orchestrator/src/share/`:

- **`GistProvider` interface** + **`fetchWithTimeout`** shared helper (extracted from the existing GitHub code to deduplicate timeout/abort handling).
- **`gist.ts`** — the existing GitHub logic becomes the `github` provider (`githubGistProvider`); `createSessionGist` keeps its public signature, so existing behaviour and the pi.dev viewer link are unchanged.
- **`opengist.ts`** (new) — `opengistGistProvider` speaks Opengist's create contract and builds the share link.
- **`provider.ts`** (new) — `resolveGistProvider()` / `resolveShareToken()` factory (kept in its own module to avoid a circular import).

### Why the Opengist share link is a raw-HTML URL

The pi.dev viewer **hardcodes `api.github.com`**, so it cannot read an Opengist gist. Instead, `share_url` points at the gist's raw web route (`<html_url>/raw/HEAD/<filename>`). The exported session HTML is self-contained (data embedded inline), and Opengist serves `.html` files with `Content-Type: text/html` + an inline disposition — and, unlike SVG/PDF, applies **no restrictive CSP** to HTML (verified in the `RawFile` handler). So the raw link renders the full session in any browser with no viewer dependency. This is the report's recommended "Option A".

## Usage

```yaml
- uses: shaftoe/pi-coding-agent-action@v2
  with:
    share_session: true
    share_gist_provider: opengist
    share_gist_api_url: https://gist.l3x.in/api/gists
    share_gist_token: ${{ secrets.OPENGIST_TOKEN }}   # og_… token, gist:write scope
```

- Gists are created as `unlisted` (the closest analogue of a GitHub "secret" gist).
- `share_gist_token` falls back to `github_token`, so the GitHub path keeps working with a single token.
- The GitHub default is untouched — this is purely additive.

## New inputs

| Input | Description | Default |
|---|---|---|
| `share_gist_provider` | `github` (default) or `opengist` | `github` |
| `share_gist_api_url` | Instance create endpoint (required for opengist, e.g. `https://gist.l3x.in/api/gists`) | — |
| `share_gist_token` | Opengist access token (`og_…`, `gist:write`); falls back to `github_token` | — |

## Changes

- `packages/pi-orchestrator/src/share/gist.ts` — `GistProvider` interface, `fetchWithTimeout`, `githubGistProvider`; refactored `createSessionGist` to use the shared helper.
- `packages/pi-orchestrator/src/share/opengist.ts` (new) — Opengist provider.
- `packages/pi-orchestrator/src/share/provider.ts` (new) — resolver + token fallback.
- `packages/pi-orchestrator/src/orchestrator.ts` — resolves provider/token; validates Opengist's required API URL.
- `packages/pi-orchestrator/src/types.ts` — new `PiConfig` fields.
- `packages/pi-action/src/adapters/config.ts` — parses the new inputs (registers `share_gist_token` as a secret).
- `action.yml` + `README.md` — new inputs/outputs + an "Opengist backend" guide.
- `dist/index.js` — rebuilt bundle.

## Tests

- `tests/share/opengist.spec.ts` (new) — HTTP contract (route, headers, `visibility`/`title` body), raw-HTML share URL derivation, missing-API-URL guard, error/timeout/malformed cases.
- `tests/share/provider.spec.ts` (new) — provider selection + token fallback.
- `tests/orchestrator.spec.ts` — Opengist end-to-end flow, missing-URL skip notice, token fallback; updated the no-token notice assertion.
- `tests/adapters/config.spec.ts` — new input parsing + secret masking.

## Validation

- `bun run validate` ✅ (ESLint + tsc + Prettier)
- `bun test` ✅ — 1606 pass / 0 fail (2 E2E skipped)
- `bun run fallow:dead-code` ✅ — no issues

## Notes / follow-ups

- The `gist:write` scope + correct `/api/gists` route are confirmed against the live Opengist docs; the `gist.l3x.in` operator just needs to ensure the REST API is enabled (`api.enabled` defaults to `true`) and issue an `og_…` token.
- Upstream still lacks a gist-creation hook and a viewer-side configurable host (the report's "Option D") — those remain the strategic fix if deep-linking through `pi.dev` is ever wanted.