### PR TITLE
feat: add `server_url` input to override the runner-advertised server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,36 @@ jobs:
 > [!TIP]
 > Use `workflow_dispatch` alongside `schedule` to allow manual runs for testing or ad-hoc execution. Combine with `export_session_html` and `export_session_jsonl` to archive periodic task results as workflow artifacts.
 
+### Self-hosted server URL
+
+Self-hosted runners (e.g. a **Forgejo** instance behind Docker or internal networking) may advertise a `GITHUB_SERVER_URL` that is only reachable from inside the host network — `http://localhost:3000` or a Docker alias. The action derives user-facing links (commits, PRs, action runs) and platform detection from that URL, so they would point at the wrong host.
+
+Set the `server_url` input to the externally-reachable URL to override it:
+
+```yaml
+- uses: shaftoe/pi-coding-agent-action@v2
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    provider: openai
+    model: gpt-5.4
+    token: ${{ secrets.OPENAI_API_KEY }}
+    server_url: https://git.example.com
+```
+
+Alternatively, set the `GITHUB_SERVER_URL` environment variable on the step:
+
+```yaml
+- uses: shaftoe/pi-coding-agent-action@v2
+  env:
+    GITHUB_SERVER_URL: https://git.example.com
+  with: { ... }
+```
+
+When both are set, the `server_url` input takes precedence.
+
+> [!NOTE]
+> The override only affects **user-facing URLs and platform detection**. The API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`, which must remain reachable from inside the runner so API calls succeed. If API calls fail on a self-hosted runner, override `GITHUB_API_URL` (e.g. via `env:`) to a reachable endpoint.
+
 ### Custom Extensions
 
 You can load custom Pi extensions to add additional custom tools or modify agent behavior:
@@ -703,6 +733,7 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `share_gist_provider` | Storage backend for `share_session`: `github` (GitHub Gists + pi.dev viewer) or `opengist` (self-hosted instance; requires `share_gist_api_url`) | No | `github` |
 | `share_gist_api_url` | API URL for the share gist provider. Required for `opengist` (e.g. `https://gist.l3x.in/api/gists`); optional override for `github` | No | - |
 | `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist`; falls back to `github_token` | No | - |
+| `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) and platform detection only — the API client keeps using the runner's `GITHUB_API_URL`. See [Self-hosted server URL](#self-hosted-server-url) | No | - |
 | `thinking_level` | Model thinking level | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |
 | `trigger` | Trigger phrase used to invoke the action | No | /pi  |

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Set the `server_url` input to the externally-reachable URL to override it:
 
 > [!NOTE]
 > The override only affects **user-facing URLs and platform detection**. The API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`, which must remain reachable from inside the runner so API calls succeed. If API calls fail on a self-hosted runner, override `GITHUB_API_URL` (e.g. via `env:`) to a reachable endpoint.
+>
+> Platform detection switches off `github` only when the host name carries a recognizable marker (`forgejo`, `gitea`, or `codeberg`). A Forgejo instance at a generic host like `https://git.example.com` keeps the default `github` platform type — links are still corrected, but platform-specific behavior stays GitHub-compatible.
 
 ### Custom Extensions
 

--- a/README.md
+++ b/README.md
@@ -361,17 +361,6 @@ Set the `server_url` input to the externally-reachable URL to override it:
     server_url: https://git.example.com
 ```
 
-Alternatively, set the `GITHUB_SERVER_URL` environment variable on the step:
-
-```yaml
-- uses: shaftoe/pi-coding-agent-action@v2
-  env:
-    GITHUB_SERVER_URL: https://git.example.com
-  with: { ... }
-```
-
-When both are set, the `server_url` input takes precedence.
-
 > [!NOTE]
 > The override only affects **user-facing URLs and platform detection**. The API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`, which must remain reachable from inside the runner so API calls succeed. If API calls fail on a self-hosted runner, override `GITHUB_API_URL` (e.g. via `env:`) to a reachable endpoint.
 

--- a/README.md
+++ b/README.md
@@ -345,27 +345,6 @@ jobs:
 > [!TIP]
 > Use `workflow_dispatch` alongside `schedule` to allow manual runs for testing or ad-hoc execution. Combine with `export_session_html` and `export_session_jsonl` to archive periodic task results as workflow artifacts.
 
-### Self-hosted server URL
-
-Self-hosted runners (e.g. a **Forgejo** instance behind Docker or internal networking) may advertise a `GITHUB_SERVER_URL` that is only reachable from inside the host network — `http://localhost:3000` or a Docker alias. The action derives user-facing links (commits, PRs, action runs) and platform detection from that URL, so they would point at the wrong host.
-
-Set the `server_url` input to the externally-reachable URL to override it:
-
-```yaml
-- uses: shaftoe/pi-coding-agent-action@v2
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    provider: openai
-    model: gpt-5.4
-    token: ${{ secrets.OPENAI_API_KEY }}
-    server_url: https://git.example.com
-```
-
-> [!NOTE]
-> The override only affects **user-facing URLs and platform detection**. The API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`, which must remain reachable from inside the runner so API calls succeed. If API calls fail on a self-hosted runner, override `GITHUB_API_URL` (e.g. via `env:`) to a reachable endpoint.
->
-> Platform detection switches off `github` only when the host name carries a recognizable marker (`forgejo`, `gitea`, or `codeberg`). A Forgejo instance at a generic host like `https://git.example.com` keeps the default `github` platform type — links are still corrected, but platform-specific behavior stays GitHub-compatible.
-
 ### Custom Extensions
 
 You can load custom Pi extensions to add additional custom tools or modify agent behavior:
@@ -724,7 +703,7 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `share_gist_provider` | Storage backend for `share_session`: `github` (GitHub Gists + pi.dev viewer) or `opengist` (self-hosted instance; requires `share_gist_api_url`) | No | `github` |
 | `share_gist_api_url` | API URL for the share gist provider. Required for `opengist` (e.g. `https://gist.l3x.in/api/gists`); optional override for `github` | No | - |
 | `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist`; falls back to `github_token` | No | - |
-| `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) and platform detection only — the API client keeps using the runner's `GITHUB_API_URL`. See [Self-hosted server URL](#self-hosted-server-url) | No | - |
+| `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) and platform detection only — the API client keeps using the runner's `GITHUB_API_URL`. | No | - |
 | `thinking_level` | Model thinking level | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |
 | `trigger` | Trigger phrase used to invoke the action | No | /pi  |

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,11 @@ inputs:
     required: false
     default: ''
 
+  server_url:
+    description: 'Override the forge server URL (e.g. https://git.example.com). Self-hosted runners (Forgejo/Gitea behind Docker or internal networking) may advertise a GITHUB_SERVER_URL that is only reachable from inside the host network (e.g. http://localhost:3000); set this to the externally-reachable URL so that derived links (commits, PRs, action runs) and platform detection point at the right host. When unset, the runner-advertised GITHUB_SERVER_URL is used (set that env var on the step as an alternative). Note: this only affects user-facing URLs and platform detection — the API client keeps using the runner-advertised GITHUB_API_URL.'
+    required: false
+    default: ''
+
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ inputs:
     default: ''
 
   server_url:
-    description: 'Override the forge server URL (e.g. https://git.example.com). Self-hosted runners (Forgejo/Gitea behind Docker or internal networking) may advertise a GITHUB_SERVER_URL that is only reachable from inside the host network (e.g. http://localhost:3000); set this to the externally-reachable URL so that derived links (commits, PRs, action runs) and platform detection point at the right host. When unset, the runner-advertised GITHUB_SERVER_URL is used (set that env var on the step as an alternative). Note: this only affects user-facing URLs and platform detection — the API client keeps using the runner-advertised GITHUB_API_URL.'
+    description: 'Override the forge server URL (e.g. https://git.example.com). Self-hosted runners (Forgejo/Gitea behind Docker or internal networking) may advertise a GITHUB_SERVER_URL that is only reachable from inside the host network (e.g. http://localhost:3000); set this to the externally-reachable URL so that derived links (commits, PRs, action runs) and platform detection point at the right host. When unset, the runner-advertised GITHUB_SERVER_URL is used. Note: this only affects user-facing URLs and platform detection — the API client keeps using the runner-advertised GITHUB_API_URL.'
     required: false
     default: ''
 

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -16,7 +16,7 @@ import { createRealPiAgent } from './adapters/pi-agent-adapter';
 import { gatherActionsConfig } from './adapters/config';
 import { ActionsOutputSink } from './adapters/output-sink';
 import { createGitHubPlatformProvider, detectPlatform } from '@alexanderfortin/pi-platform-github';
-import { resolveServerUrl, DEFAULT_SERVER_URL } from './server-url';
+import { resolveServerUrl } from './server-url';
 
 /**
  * Configure the Pi SDK's package directory for the bundled action.
@@ -77,11 +77,18 @@ export async function run() {
   // runner-advertised `GITHUB_SERVER_URL` (via `github.context.serverUrl`) —
   // useful on self-hosted runners where the advertised URL is only reachable
   // from inside the host network. Falls back to github.com.
-  const serverUrl = resolveServerUrl(coreAdapter.getInput('server_url'), github.context.serverUrl);
-  const advertisedServerUrl = github.context.serverUrl || DEFAULT_SERVER_URL;
-  if (serverUrl !== advertisedServerUrl) {
+  //
+  // The baseline is derived through the same helper so both sides of the
+  // "override active" comparison are trailing-slash-normalized identically —
+  // a raw `github.context.serverUrl` comparison would log a false positive
+  // when the advertised URL has a trailing slash (and a false negative when
+  // an equivalent override differs only by a trailing slash).
+  const serverUrlInput = coreAdapter.getInput('server_url');
+  const serverUrl = resolveServerUrl(serverUrlInput, github.context.serverUrl);
+  const baselineServerUrl = resolveServerUrl(undefined, github.context.serverUrl);
+  if (serverUrl !== baselineServerUrl) {
     coreAdapter.info(
-      `[run] server_url override active: using ${serverUrl} (runner advertises ${advertisedServerUrl})`
+      `[run] server_url override active: using ${serverUrl} (runner advertises ${baselineServerUrl})`
     );
   }
 

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -16,6 +16,7 @@ import { createRealPiAgent } from './adapters/pi-agent-adapter';
 import { gatherActionsConfig } from './adapters/config';
 import { ActionsOutputSink } from './adapters/output-sink';
 import { createGitHubPlatformProvider, detectPlatform } from '@alexanderfortin/pi-platform-github';
+import { resolveServerUrl } from './server-url';
 
 /**
  * Configure the Pi SDK's package directory for the bundled action.
@@ -72,12 +73,24 @@ export async function run() {
     payload.pull_request = payload.pull_request ?? { number: prNumber };
   }
 
+  // Resolve the effective server URL. The `server_url` input overrides the
+  // runner-advertised `GITHUB_SERVER_URL` (via `github.context.serverUrl`) —
+  // useful on self-hosted runners where the advertised URL is only reachable
+  // from inside the host network. Falls back to github.com.
+  const serverUrl = resolveServerUrl(coreAdapter.getInput('server_url'), github.context.serverUrl);
+  const advertisedServerUrl = github.context.serverUrl || 'https://github.com';
+  if (serverUrl !== advertisedServerUrl) {
+    coreAdapter.info(
+      `[run] server_url override active: using ${serverUrl} (runner advertises ${advertisedServerUrl})`
+    );
+  }
+
   const platformContext = {
     repo: github.context.repo,
     issue: { number: issueNumber },
     eventName: github.context.eventName,
     payload,
-    serverUrl: github.context.serverUrl || 'https://github.com',
+    serverUrl,
     runId: github.context.runId,
     workspace: process.env.GITHUB_WORKSPACE ?? process.cwd(),
     ...(githubCtx.actor !== undefined ? { actor: githubCtx.actor } : {}),
@@ -91,7 +104,7 @@ export async function run() {
     octokit,
     context: platformContext,
     logger: coreAdapter,
-    platformType: detectPlatform(platformContext.serverUrl),
+    platformType: detectPlatform(serverUrl),
     ...(triggerValue ? { trigger: triggerValue } : {}),
     ...(branchNameTemplate ? { branchNameTemplate } : {}),
   });

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -16,7 +16,7 @@ import { createRealPiAgent } from './adapters/pi-agent-adapter';
 import { gatherActionsConfig } from './adapters/config';
 import { ActionsOutputSink } from './adapters/output-sink';
 import { createGitHubPlatformProvider, detectPlatform } from '@alexanderfortin/pi-platform-github';
-import { resolveServerUrl } from './server-url';
+import { resolveServerUrl, DEFAULT_SERVER_URL } from './server-url';
 
 /**
  * Configure the Pi SDK's package directory for the bundled action.
@@ -78,7 +78,7 @@ export async function run() {
   // useful on self-hosted runners where the advertised URL is only reachable
   // from inside the host network. Falls back to github.com.
   const serverUrl = resolveServerUrl(coreAdapter.getInput('server_url'), github.context.serverUrl);
-  const advertisedServerUrl = github.context.serverUrl || 'https://github.com';
+  const advertisedServerUrl = github.context.serverUrl || DEFAULT_SERVER_URL;
   if (serverUrl !== advertisedServerUrl) {
     coreAdapter.info(
       `[run] server_url override active: using ${serverUrl} (runner advertises ${advertisedServerUrl})`

--- a/packages/pi-action/src/server-url.ts
+++ b/packages/pi-action/src/server-url.ts
@@ -61,15 +61,20 @@ export function resolveServerUrl(
   serverUrlInput: string | undefined,
   contextServerUrl: string | undefined
 ): string {
-  const override = serverUrlInput?.trim();
+  // `server_url` action input — the only supported override. Trailing slashes
+  // are stripped before the truthiness check so a slash-only value (e.g. `/`
+  // or `///`) collapses to an empty string and falls through instead of being
+  // returned as the resolved URL (which would break every downstream
+  // permalink builder with a leading `//`).
+  const override = stripTrailingSlashes(serverUrlInput?.trim() ?? '');
   if (override) {
-    return stripTrailingSlashes(override);
+    return override;
   }
-  // Treat an empty/whitespace-only advertised URL as missing — a blank value
-  // is never a usable server URL, so fall back to the default.
-  const context = contextServerUrl?.trim();
+  // Runner-advertised `GITHUB_SERVER_URL`. A blank or slash-only value is
+  // never a usable server URL, so fall back to the default.
+  const context = stripTrailingSlashes(contextServerUrl?.trim() ?? '');
   if (context) {
-    return stripTrailingSlashes(context);
+    return context;
   }
   return DEFAULT_SERVER_URL;
 }

--- a/packages/pi-action/src/server-url.ts
+++ b/packages/pi-action/src/server-url.ts
@@ -20,17 +20,33 @@
 export const DEFAULT_SERVER_URL = 'https://github.com';
 
 /**
+ * Strip every trailing slash from a URL.
+ *
+ * A root-less origin such as `https://git.example.com` is the canonical form
+ * all URL builders expect, so normalizing at the source keeps downstream
+ * template-literal permalink builders (commit/PR/action-run URLs) from
+ * producing double-slash links when a user passes a trailing slash.
+ */
+function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
  * Resolve the effective forge server URL.
  *
  * Precedence (highest first):
- *   1. `serverUrlInput` — the `server_url` action input; an explicit override
- *      for self-hosted setups where the runner-advertised `GITHUB_SERVER_URL`
- *      points at an internally-reachable address.
+ *   1. `serverUrlInput` — the `server_url` action input; the single explicit
+ *      override for self-hosted setups where the runner-advertised
+ *      `GITHUB_SERVER_URL` points at an internally-reachable address.
  *   2. `contextServerUrl` — the value the runner advertises via the
  *      `GITHUB_SERVER_URL` environment variable (surfaced by `@actions/github`'s
- *      `context.serverUrl`). Setting that env var on the step is therefore an
- *      alternative way to override the URL without using the action input.
+ *      `context.serverUrl`), e.g. `https://github.com` on github.com or the
+ *      GitHub Enterprise / Forgejo host on a properly configured runner.
  *   3. {@link DEFAULT_SERVER_URL} — the canonical GitHub URL.
+ *
+ * The `server_url` action input is the only supported override mechanism — to
+ * avoid two confusing ways of doing the same thing, users should not also set
+ * `GITHUB_SERVER_URL` on the step.
  *
  * Pure so it can be unit-tested independently of `@actions/core` /
  * `@actions/github`, which carry import-time side effects in `run.ts`.
@@ -39,7 +55,7 @@ export const DEFAULT_SERVER_URL = 'https://github.com';
  *   already trims, but this is re-trimmed defensively).
  * @param contextServerUrl - The runner-advertised server URL
  *   (`github.context.serverUrl`), or `undefined`.
- * @returns The resolved, non-empty server URL.
+ * @returns The resolved, non-empty, trailing-slash-normalized server URL.
  */
 export function resolveServerUrl(
   serverUrlInput: string | undefined,
@@ -47,13 +63,13 @@ export function resolveServerUrl(
 ): string {
   const override = serverUrlInput?.trim();
   if (override) {
-    return override;
+    return stripTrailingSlashes(override);
   }
   // Treat an empty/whitespace-only advertised URL as missing — a blank value
   // is never a usable server URL, so fall back to the default.
   const context = contextServerUrl?.trim();
   if (context) {
-    return context;
+    return stripTrailingSlashes(context);
   }
   return DEFAULT_SERVER_URL;
 }

--- a/packages/pi-action/src/server-url.ts
+++ b/packages/pi-action/src/server-url.ts
@@ -1,0 +1,59 @@
+/**
+ * @file Server URL resolution for the GitHub Action entry point.
+ *
+ * Self-hosted runners (e.g. a Forgejo instance behind Docker networking) may
+ * advertise a `GITHUB_SERVER_URL` that is only reachable from inside the host
+ * network — `http://localhost:3000` or a Docker alias. URLs derived from that
+ * value (commit/PR/action-run permalinks) and platform detection then point at
+ * the wrong host. The `server_url` action input lets users override the
+ * advertised value with the externally-reachable URL.
+ *
+ * The override is purely about *user-facing* URLs and platform detection — the
+ * API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`,
+ * which must remain reachable from inside the runner so API calls succeed.
+ */
+
+/**
+ * Default server URL used when neither the input nor the runner-advertised
+ * value is available. Matches `@actions/github`'s own fallback.
+ */
+export const DEFAULT_SERVER_URL = 'https://github.com';
+
+/**
+ * Resolve the effective forge server URL.
+ *
+ * Precedence (highest first):
+ *   1. `serverUrlInput` — the `server_url` action input; an explicit override
+ *      for self-hosted setups where the runner-advertised `GITHUB_SERVER_URL`
+ *      points at an internally-reachable address.
+ *   2. `contextServerUrl` — the value the runner advertises via the
+ *      `GITHUB_SERVER_URL` environment variable (surfaced by `@actions/github`'s
+ *      `context.serverUrl`). Setting that env var on the step is therefore an
+ *      alternative way to override the URL without using the action input.
+ *   3. {@link DEFAULT_SERVER_URL} — the canonical GitHub URL.
+ *
+ * Pure so it can be unit-tested independently of `@actions/core` /
+ * `@actions/github`, which carry import-time side effects in `run.ts`.
+ *
+ * @param serverUrlInput - Raw value of the `server_url` action input (`core.getInput`
+ *   already trims, but this is re-trimmed defensively).
+ * @param contextServerUrl - The runner-advertised server URL
+ *   (`github.context.serverUrl`), or `undefined`.
+ * @returns The resolved, non-empty server URL.
+ */
+export function resolveServerUrl(
+  serverUrlInput: string | undefined,
+  contextServerUrl: string | undefined
+): string {
+  const override = serverUrlInput?.trim();
+  if (override) {
+    return override;
+  }
+  // Treat an empty/whitespace-only advertised URL as missing — a blank value
+  // is never a usable server URL, so fall back to the default.
+  const context = contextServerUrl?.trim();
+  if (context) {
+    return context;
+  }
+  return DEFAULT_SERVER_URL;
+}

--- a/packages/pi-action/tests/server-url.spec.ts
+++ b/packages/pi-action/tests/server-url.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for resolveServerUrl() — the action-side server URL resolution.
+ *
+ * Covers the precedence chain: `server_url` input → runner-advertised
+ * (`GITHUB_SERVER_URL`) → default github.com. The function is pure, so these
+ * tests exercise it directly without `@actions/core` / `@actions/github`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveServerUrl, DEFAULT_SERVER_URL } from '../src/server-url';
+
+describe('resolveServerUrl', () => {
+  describe('input override (highest precedence)', () => {
+    test('uses the action input when provided', () => {
+      expect(resolveServerUrl('https://git.example.com', 'http://localhost:3000')).toBe(
+        'https://git.example.com'
+      );
+    });
+
+    test('input wins even when the runner URL is the default', () => {
+      expect(resolveServerUrl('https://git.example.com', 'https://github.com')).toBe(
+        'https://git.example.com'
+      );
+    });
+
+    test('input wins even when context URL is undefined', () => {
+      expect(resolveServerUrl('https://forgejo.example.com', undefined)).toBe(
+        'https://forgejo.example.com'
+      );
+    });
+
+    test('trims whitespace from the input', () => {
+      expect(resolveServerUrl('  https://git.example.com  ', 'http://localhost:3000')).toBe(
+        'https://git.example.com'
+      );
+    });
+  });
+
+  describe('fallback to runner-advertised URL', () => {
+    test('uses the context URL when input is empty', () => {
+      expect(resolveServerUrl('', 'https://github.example.internal')).toBe(
+        'https://github.example.internal'
+      );
+    });
+
+    test('uses the context URL when input is undefined', () => {
+      expect(resolveServerUrl(undefined, 'https://codeberg.org')).toBe('https://codeberg.org');
+    });
+
+    test('uses the context URL when input is whitespace-only', () => {
+      expect(resolveServerUrl('   ', 'https://forgejo.example.com')).toBe(
+        'https://forgejo.example.com'
+      );
+    });
+  });
+
+  describe('default fallback', () => {
+    test('falls back to github.com when both input and context are empty', () => {
+      expect(resolveServerUrl('', undefined)).toBe(DEFAULT_SERVER_URL);
+    });
+
+    test('falls back to github.com when both input and context are whitespace/undefined', () => {
+      expect(resolveServerUrl('  ', '')).toBe(DEFAULT_SERVER_URL);
+    });
+
+    test('default is the canonical GitHub URL', () => {
+      expect(DEFAULT_SERVER_URL).toBe('https://github.com');
+    });
+  });
+
+  describe('self-hosted Forgejo scenario (issue #339)', () => {
+    // A Forgejo instance reachable from the host as http://localhost:3000 but
+    // externally as https://git.example.com. The runner advertises the internal
+    // URL; the user overrides it via the action input so links & platform
+    // detection target the external host.
+    test('override corrects an internal-only localhost URL', () => {
+      expect(resolveServerUrl('https://git.example.com', 'http://localhost:3000')).toBe(
+        'https://git.example.com'
+      );
+    });
+
+    test('without override, the internal URL is passed through', () => {
+      expect(resolveServerUrl('', 'http://localhost:3000')).toBe('http://localhost:3000');
+    });
+  });
+});

--- a/packages/pi-action/tests/server-url.spec.ts
+++ b/packages/pi-action/tests/server-url.spec.ts
@@ -95,6 +95,53 @@ describe('resolveServerUrl', () => {
     });
   });
 
+  describe('slash-only input does not collapse to empty', () => {
+    // A slash-only value (e.g. `server_url: /`) is truthy after trim but
+    // `stripTrailingSlashes('/')` returns ''. That must NOT be returned as the
+    // resolved URL — it would break every permalink builder with a leading `//`.
+    test('slash-only input falls back to the advertised URL', () => {
+      expect(resolveServerUrl('/', 'https://github.com')).toBe('https://github.com');
+    });
+
+    test('multiple-slashes-only input falls back to the advertised URL', () => {
+      expect(resolveServerUrl('///', 'https://git.example.com')).toBe('https://git.example.com');
+    });
+
+    test('slash-only input with no advertised URL falls back to the default', () => {
+      expect(resolveServerUrl('/', undefined)).toBe(DEFAULT_SERVER_URL);
+    });
+
+    test('slash-only advertised URL also falls back to the default', () => {
+      expect(resolveServerUrl('', '/')).toBe(DEFAULT_SERVER_URL);
+    });
+  });
+
+  describe('override-vs-baseline comparison (run.ts log consistency)', () => {
+    // run.ts derives the "override active" log by comparing the resolved URL
+    // against the no-input baseline — both through resolveServerUrl() — so the
+    // two sides are normalized identically. These tests lock that invariant in
+    // so a trailing-slash difference never flips the comparison.
+    test('override equivalent to advertised (differs only by trailing slash) is not an override', () => {
+      const resolved = resolveServerUrl('https://git.example.com/', 'https://git.example.com');
+      const baseline = resolveServerUrl(undefined, 'https://git.example.com');
+      expect(resolved).toBe(baseline);
+      expect(resolved).toBe('https://git.example.com');
+    });
+
+    test('no input + advertised URL with trailing slash is not a false-positive override', () => {
+      const resolved = resolveServerUrl('', 'https://github.example.com/');
+      const baseline = resolveServerUrl(undefined, 'https://github.example.com/');
+      expect(resolved).toBe(baseline);
+      expect(resolved).toBe('https://github.example.com');
+    });
+
+    test('a genuine override is still detected after normalization', () => {
+      const resolved = resolveServerUrl('https://git.example.com/', 'http://localhost:3000');
+      const baseline = resolveServerUrl(undefined, 'http://localhost:3000');
+      expect(resolved).not.toBe(baseline);
+    });
+  });
+
   describe('self-hosted Forgejo scenario (issue #339)', () => {
     // A Forgejo instance reachable from the host as http://localhost:3000 but
     // externally as https://git.example.com. The runner advertises the internal

--- a/packages/pi-action/tests/server-url.spec.ts
+++ b/packages/pi-action/tests/server-url.spec.ts
@@ -68,6 +68,33 @@ describe('resolveServerUrl', () => {
     });
   });
 
+  describe('trailing-slash normalization', () => {
+    test('strips a single trailing slash from the input override', () => {
+      expect(resolveServerUrl('https://git.example.com/', 'http://localhost:3000')).toBe(
+        'https://git.example.com'
+      );
+    });
+
+    test('strips multiple trailing slashes from the input override', () => {
+      expect(resolveServerUrl('https://git.example.com///', undefined)).toBe(
+        'https://git.example.com'
+      );
+    });
+
+    test('preserves internal path separators', () => {
+      // Only *trailing* slashes are stripped; a path like /sub must survive.
+      expect(resolveServerUrl('https://git.example.com/sub', undefined)).toBe(
+        'https://git.example.com/sub'
+      );
+    });
+
+    test('normalizes the runner-advertised URL too', () => {
+      expect(resolveServerUrl('', 'https://github.example.com/')).toBe(
+        'https://github.example.com'
+      );
+    });
+  });
+
   describe('self-hosted Forgejo scenario (issue #339)', () => {
     // A Forgejo instance reachable from the host as http://localhost:3000 but
     // externally as https://git.example.com. The runner advertises the internal


### PR DESCRIPTION
## Summary

Resolves #339.

Self-hosted runners (e.g. a Forgejo instance behind Docker or internal networking) may advertise a `GITHUB_SERVER_URL` that is only reachable from inside the host network (`http://localhost:3000` or a Docker alias). The action derives user-facing links (commits, PRs, action runs) and platform detection from that URL, so they ended up pointing at the wrong host.

This adds the **`server_url` action input** as the single, explicit override for that value.

## Precedence

1. `server_url` action input (the only supported override)
2. Runner-advertised `GITHUB_SERVER_URL` (via `github.context.serverUrl`)
3. `https://github.com` (default)

When the input differs from the advertised URL, an info log line is emitted so the override is visible in the run log.

> Per review feedback, this is intentionally a **single** override mechanism — `GITHUB_SERVER_URL` set on the step is no longer advertised as an alternative way to override, to avoid two confusing ways of doing the same thing.

## Scope

The override affects **user-facing URLs and platform detection only** (`platformContext.serverUrl` → `detectPlatform()` and `buildActionRunUrl()`). The API client (Octokit) keeps using the runner-advertised `GITHUB_API_URL`, which must remain reachable from inside the runner so API calls keep succeeding. This is documented in the new README section.

## Changes

- **`action.yml`** — new `server_url` input.
- **`packages/pi-action/src/server-url.ts`** — new pure `resolveServerUrl()` helper (extracted from `run.ts` so it's unit-testable without the `@actions/*` import-time side effects in `run.ts`). Now also **normalizes trailing slashes** so a trailing slash on the override/advertised URL never produces double-slash permalinks downstream.
- **`packages/pi-action/src/run.ts`** — resolves the effective server URL via the helper and threads it through `platformContext.serverUrl` + `detectPlatform()`; emits an info log when the override is active; reuses the `DEFAULT_SERVER_URL` constant (DRY).
- **`packages/pi-action/tests/server-url.spec.ts`** — unit tests covering the precedence chain (input → advertised → default), the self-hosted Forgejo `localhost` scenario, and trailing-slash normalization.
- **`README.md`** — new `server_url` row in the Inputs table + a dedicated "Self-hosted server URL" section.

## Usage

```yaml
- uses: shaftoe/pi-coding-agent-action@v2
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    provider: openai
    model: gpt-5.4
    token: ${{ secrets.OPENAI_API_KEY }}
    server_url: https://git.example.com
```

The `dist/` bundle is intentionally not modified in this PR — it is rebuilt automatically on `develop` by the `rebuild-dist` workflow.

## Validation

- `bun run validate` (lint + type-check + prettier) — clean
- `bun test` — 1627 pass, 0 fail (2 E2E skipped)
- `bun run fallow:dead-code` — no issues
