### PR TITLE
fix: correct Forgejo/Codeberg "View action run" footer link URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Monorepo managed with Bun workspaces (`packages/*`):
   - `src/tools/` — GitHub-specific tools (CI status, workflow logs, PR create/update, reviews, thread, diff).
   - `src/git/` — GitHub git operations (commit creator, tree builder, file scanner).
   - `src/{reactions,comments,context,context-utils,constants}.ts` — Supporting modules.
-  - Platform detection via `detectPlatform()` (uses `GITHUB_SERVER_URL` env var).
+  - Platform selection via the `platform` input / `--platform` flag, resolved by `parsePlatformType()` (defaults to `github`).
 
 - **`packages/pi-action`** (`@alexanderfortin/pi-action`, private) — GitHub Action entry point. Depends on both packages above.
   - `src/run.ts` — Action entrypoint.

--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `load_builtin_extensions` | Whether to load built-in GitHub tools (see [Custom Tools](#custom-tools) for the full list) | No | `true` |
 | `loaded_tools` | Controls which tools are available in the session. Defaults to `all`. Accepts a list of tool names (one per line) to load — unknown names cause the run to fail early | No | `all` |
 | `model` | Model to use (e.g., gpt-5.4, gpt-4o, gemini-2.5-pro) | Yes | - |
+| `platform` | Git hosting platform the action is running on: `github` (default), `codeberg`, `forgejo`, or `gitea` (alias for `forgejo`). Determines platform-specific behaviour such as the action-run URL format in the "View action run" footer. The platform is **no longer auto-detected** from the server URL — set it explicitly when running on Forgejo/Codeberg/Gitea (e.g. `platform: forgejo`) | No | `github` |
 | `pr_number` | Pull request number to target. Use with `workflow_dispatch` to run the agent on a specific PR without a triggering event. When set, the action fetches PR context from the API and targets all operations at the specified PR | No | - |
 | `prompt` | Optional prompt to send to the agent (skips comment extraction) | No | - |
 | `provider` | LLM provider (openai, google, anthropic, etc.) | Yes | - |
@@ -703,7 +704,7 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `share_gist_provider` | Storage backend for `share_session`: `github` (GitHub Gists + pi.dev viewer) or `opengist` (self-hosted instance; requires `share_gist_api_url`) | No | `github` |
 | `share_gist_api_url` | API URL for the share gist provider. Required for `opengist` (e.g. `https://gist.l3x.in/api/gists`); optional override for `github` | No | - |
 | `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist`; falls back to `github_token` | No | - |
-| `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) and platform detection only — the API client keeps using the runner's `GITHUB_API_URL`. | No | - |
+| `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) only — the API client keeps using the runner's `GITHUB_API_URL`, and platform selection is controlled by the `platform` input. | No | - |
 | `thinking_level` | Model thinking level | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |
 | `trigger` | Trigger phrase used to invoke the action | No | /pi  |
@@ -771,7 +772,7 @@ Refer to [the official Pi documentation](https://pi.dev/docs/latest) to learn ho
 ## Disclaimer
 
 > [!NOTE]
-> Codeberg/Forgejo compatibility has been confirmed on self-hosted **Forgejo** instances, where the action runs the Pi agent as expected (at least in non-interactive mode). Not every feature has been exercised yet on these platforms — PRs documenting additional coverage are welcome.
+> Codeberg/Forgejo compatibility has been confirmed on self-hosted **Forgejo** instances, where the action runs the Pi agent as expected (at least in non-interactive mode). When running on Forgejo/Codeberg/Gitea, set the `platform` input (e.g. `platform: forgejo`) so platform-specific behaviour — such as the job-level action-run URL in the "View action run" footer — uses the correct format. Not every feature has been exercised yet on these platforms — PRs documenting additional coverage are welcome.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -115,8 +115,13 @@ inputs:
     required: false
     default: ''
 
+  platform:
+    description: 'Git hosting platform the action is running on. One of github (default), codeberg, forgejo, or gitea (alias for forgejo). Determines platform-specific behaviour such as the action-run URL format used in the "View action run" footer. The platform is no longer auto-detected from the server URL, so set this explicitly when running on Forgejo/Codeberg/Gitea (e.g. platform: forgejo).'
+    required: false
+    default: 'github'
+
   server_url:
-    description: 'Override the forge server URL (e.g. https://git.example.com). Self-hosted runners (Forgejo/Gitea behind Docker or internal networking) may advertise a GITHUB_SERVER_URL that is only reachable from inside the host network (e.g. http://localhost:3000); set this to the externally-reachable URL so that derived links (commits, PRs, action runs) and platform detection point at the right host. When unset, the runner-advertised GITHUB_SERVER_URL is used. Note: this only affects user-facing URLs and platform detection — the API client keeps using the runner-advertised GITHUB_API_URL.'
+    description: 'Override the forge server URL (e.g. https://git.example.com). Self-hosted runners (Forgejo/Gitea behind Docker or internal networking) may advertise a GITHUB_SERVER_URL that is only reachable from inside the host network (e.g. http://localhost:3000); set this to the externally-reachable URL so that derived links (commits, PRs, action runs) point at the right host. When unset, the runner-advertised GITHUB_SERVER_URL is used. Note: this only affects user-facing URLs — the API client keeps using the runner-advertised GITHUB_API_URL, and platform selection is controlled by the platform input.'
     required: false
     default: ''
 

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -15,7 +15,10 @@ import { RealGitAdapter } from './adapters/git-adapter';
 import { createRealPiAgent } from './adapters/pi-agent-adapter';
 import { gatherActionsConfig } from './adapters/config';
 import { ActionsOutputSink } from './adapters/output-sink';
-import { createGitHubPlatformProvider, detectPlatform } from '@alexanderfortin/pi-platform-github';
+import {
+  createGitHubPlatformProvider,
+  parsePlatformType,
+} from '@alexanderfortin/pi-platform-github';
 import { resolveServerUrl } from './server-url';
 
 /**
@@ -112,12 +115,16 @@ export async function run() {
   // Create the platform provider with explicit deps (no singletons)
   const triggerValue = coreAdapter.getInput('trigger');
   const branchNameTemplate = coreAdapter.getInput('branch_name_template');
-  // Detect platform using both the resolved server URL and the
-  // runner-advertised GITHUB_API_URL. The API URL is the most reliable
-  // signal for distinguishing self-hosted Forgejo (/api/v1) from
-  // self-hosted GitHub Enterprise (/api/v3) when the server hostname
-  // doesn't contain "forgejo"/"gitea"/"codeberg" (e.g. forge.example.com).
-  const platformType = detectPlatform(serverUrl, process.env.GITHUB_API_URL);
+  // Platform is an explicit input (default: github). It is no longer
+  // auto-detected from the server URL — hostname-based detection could
+  // not reliably distinguish self-hosted Forgejo from self-hosted GitHub
+  // Enterprise, so users set `platform` directly (e.g. forgejo).
+  const platformType = parsePlatformType(coreAdapter.getInput('platform'), raw =>
+    coreAdapter.warning(
+      `Unknown platform "${raw}"; falling back to github. ` +
+        'Valid values are github, codeberg, forgejo (or gitea).'
+    )
+  );
   const platformProvider = createGitHubPlatformProvider({
     octokit,
     context: platformContext,

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -95,6 +95,14 @@ export async function run() {
     );
   }
 
+  // GITHUB_RUN_ATTEMPT is 1 for the first run and increments on re-runs.
+  // Forgejo/Codeberg action-run URLs include it as an /attempt/{n} segment.
+  // Guard against malformed values (NaN/0) that would bypass the ?? 1
+  // fallback in buildActionRunUrl.
+  const runAttemptNum = Number(process.env.GITHUB_RUN_ATTEMPT);
+  const runAttempt =
+    Number.isFinite(runAttemptNum) && runAttemptNum > 0 ? runAttemptNum : undefined;
+
   const platformContext = {
     repo: github.context.repo,
     issue: { number: issueNumber },
@@ -102,11 +110,7 @@ export async function run() {
     payload,
     serverUrl,
     runId: github.context.runId,
-    // GITHUB_RUN_ATTEMPT is 1 for the first run and increments on re-runs.
-    // Forgejo/Codeberg action-run URLs include it as an /attempt/{n} segment.
-    ...(process.env.GITHUB_RUN_ATTEMPT
-      ? { runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT) }
-      : {}),
+    ...(runAttempt !== undefined ? { runAttempt } : {}),
     workspace: process.env.GITHUB_WORKSPACE ?? process.cwd(),
     ...(githubCtx.actor !== undefined ? { actor: githubCtx.actor } : {}),
     ...(githubCtx.sha !== undefined ? { sha: githubCtx.sha } : {}),

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -99,6 +99,11 @@ export async function run() {
     payload,
     serverUrl,
     runId: github.context.runId,
+    // GITHUB_RUN_ATTEMPT is 1 for the first run and increments on re-runs.
+    // Forgejo/Codeberg action-run URLs include it as an /attempt/{n} segment.
+    ...(process.env.GITHUB_RUN_ATTEMPT
+      ? { runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT) }
+      : {}),
     workspace: process.env.GITHUB_WORKSPACE ?? process.cwd(),
     ...(githubCtx.actor !== undefined ? { actor: githubCtx.actor } : {}),
     ...(githubCtx.sha !== undefined ? { sha: githubCtx.sha } : {}),
@@ -107,11 +112,17 @@ export async function run() {
   // Create the platform provider with explicit deps (no singletons)
   const triggerValue = coreAdapter.getInput('trigger');
   const branchNameTemplate = coreAdapter.getInput('branch_name_template');
+  // Detect platform using both the resolved server URL and the
+  // runner-advertised GITHUB_API_URL. The API URL is the most reliable
+  // signal for distinguishing self-hosted Forgejo (/api/v1) from
+  // self-hosted GitHub Enterprise (/api/v3) when the server hostname
+  // doesn't contain "forgejo"/"gitea"/"codeberg" (e.g. forge.example.com).
+  const platformType = detectPlatform(serverUrl, process.env.GITHUB_API_URL);
   const platformProvider = createGitHubPlatformProvider({
     octokit,
     context: platformContext,
     logger: coreAdapter,
-    platformType: detectPlatform(serverUrl),
+    platformType,
     ...(triggerValue ? { trigger: triggerValue } : {}),
     ...(branchNameTemplate ? { branchNameTemplate } : {}),
   });

--- a/packages/pi-cli/src/commands/run.ts
+++ b/packages/pi-cli/src/commands/run.ts
@@ -12,8 +12,7 @@
 import { ActionOrchestrator } from '@alexanderfortin/pi-orchestrator';
 import {
   createGitHubPlatformProvider,
-  detectPlatform,
-  isKnownServerUrl,
+  parsePlatformType,
 } from '@alexanderfortin/pi-platform-github';
 import { CliGitAdapter } from '../adapters/git-adapter.js';
 import { CliLogger, type LogLevel } from '../adapters/logger.js';
@@ -35,6 +34,7 @@ export interface RunCommandArgs {
   model: string;
   cwd: string;
   serverUrl: string;
+  platform: string;
   verbose: boolean;
   quiet: boolean;
 }
@@ -104,18 +104,12 @@ export async function runCommand(args: RunCommandArgs): Promise<void> {
     workspace: args.cwd,
     serverUrl: args.serverUrl,
   });
-  const platformType = detectPlatform(args.serverUrl);
-  // detectPlatform silently falls back to 'github' for unrecognized hosts
-  // (correct behavior for self-hosted GHE) but a user who mistypes a
-  // GitLab/Bitbucket URL would otherwise hit confusing GitHub-API 404s.
-  // Surface a warning so they can correct --server-url before the run.
-  if (!isKnownServerUrl(args.serverUrl)) {
+  const platformType = parsePlatformType(args.platform, raw =>
     logger.warning(
-      `Unrecognized git host '${args.serverUrl}'; assuming GitHub-compatible API. ` +
-        `If targeting GitLab/Bitbucket, set --server-url to a GitHub/Codeberg/Forgejo host ` +
-        `or expect API errors.`
-    );
-  }
+      `Unknown platform '${raw}'; falling back to github. ` +
+        `Valid values are github, codeberg, forgejo, or gitea.`
+    )
+  );
   const provider = createGitHubPlatformProvider({
     octokit,
     context: platformContext,

--- a/packages/pi-cli/src/index.ts
+++ b/packages/pi-cli/src/index.ts
@@ -65,8 +65,14 @@ export function buildProgram(): Command {
     .option('--cwd <path>', 'Working directory for the agent.', process.cwd())
     .option(
       '--server-url <url>',
-      'Git host server URL. Drives platform detection and Octokit base URL.',
+      'Git host server URL. Drives the Octokit REST API base URL for non-github.com hosts.',
       'https://github.com'
+    )
+    .option(
+      '--platform <id>',
+      'Git hosting platform: github (default), codeberg, forgejo, or gitea (alias for forgejo). ' +
+        'Determines platform-specific behaviour such as action-run URL format.',
+      'github'
     )
     .option('--verbose', 'Show debug-level logs (mutually exclusive with --quiet).')
     .option('--quiet', 'Suppress all logs except errors (mutually exclusive with --verbose).')

--- a/packages/pi-orchestrator/src/platform/types.ts
+++ b/packages/pi-orchestrator/src/platform/types.ts
@@ -44,6 +44,15 @@ export interface PlatformContext {
    * which suppresses the "View action run" footer on posted comments.
    */
   runId?: number;
+  /**
+   * The current workflow run attempt number (1 for the first attempt,
+   * incrementing on each re-run). Read from `GITHUB_RUN_ATTEMPT`.
+   *
+   * Optional so non-CI frontends can omit it; `buildActionRunUrl()`
+   * defaults to `1` when absent. Used by Forgejo/Codeberg whose
+   * action-run URLs include an `/attempt/{n}` segment.
+   */
+  runAttempt?: number;
   /** The workspace directory path */
   workspace: string;
   /** The user/actor who triggered the workflow (e.g. for Co-authored-by trailers). */

--- a/packages/pi-platform-github/src/comments.ts
+++ b/packages/pi-platform-github/src/comments.ts
@@ -67,7 +67,11 @@ export function buildActionRunUrl(deps: GitHubModuleDeps): string | undefined {
   // Forgejo/Codeberg/Gitea require a job-level URL with an attempt segment.
   const isForgejoLike = deps.platformType === 'forgejo' || deps.platformType === 'codeberg';
   if (isForgejoLike) {
-    const attempt = deps.context.runAttempt ?? 1;
+    // Defensive guard: a malformed runAttempt (NaN/0) would otherwise
+    // slip past the default and produce an invalid /attempt/NaN URL.
+    const rawAttempt = deps.context.runAttempt;
+    const attempt =
+      rawAttempt !== undefined && Number.isFinite(rawAttempt) && rawAttempt > 0 ? rawAttempt : 1;
     return `${baseUrl}/jobs/0/attempt/${attempt}`;
   }
 

--- a/packages/pi-platform-github/src/comments.ts
+++ b/packages/pi-platform-github/src/comments.ts
@@ -42,8 +42,17 @@ export type CreateCommentType =
 // ---------------------------------------------------------------------------
 
 /**
- * Build the GitHub Actions run URL from a deps context, or return
+ * Build the GitHub/Forgejo Actions run URL from a deps context, or return
  * `undefined` when any required field is missing.
+ *
+ * URL formats differ by platform:
+ * - **GitHub** (incl. GitHub Enterprise): `{server}/{owner}/{repo}/actions/runs/{runId}`
+ * - **Forgejo / Codeberg / Gitea**: `{server}/{owner}/{repo}/actions/runs/{runId}/jobs/{jobIndex}/attempt/{attempt}`
+ *
+ * Forgejo's web UI requires the job-level suffix (`/jobs/0/attempt/1`) — the
+ * bare run URL does not resolve. The job index defaults to `0` (the first —
+ * and typically only — job in a workflow that uses this action). The attempt
+ * number comes from `context.runAttempt` (defaults to `1`).
  */
 // fallow-ignore-next-line complexity
 export function buildActionRunUrl(deps: GitHubModuleDeps): string | undefined {
@@ -53,7 +62,16 @@ export function buildActionRunUrl(deps: GitHubModuleDeps): string | undefined {
   if (!owner || !repo || !runId) {
     return undefined;
   }
-  return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+  const baseUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+
+  // Forgejo/Codeberg/Gitea require a job-level URL with an attempt segment.
+  const isForgejoLike = deps.platformType === 'forgejo' || deps.platformType === 'codeberg';
+  if (isForgejoLike) {
+    const attempt = deps.context.runAttempt ?? 1;
+    return `${baseUrl}/jobs/0/attempt/${attempt}`;
+  }
+
+  return baseUrl;
 }
 
 /**

--- a/packages/pi-platform-github/src/index.ts
+++ b/packages/pi-platform-github/src/index.ts
@@ -130,9 +130,8 @@ export { resolveGitHubToken } from './auth';
 
 // Platform provider (used by platform/index.ts)
 export {
-  detectPlatform,
+  parsePlatformType,
   apiBaseUrlFromServerUrl,
-  isKnownServerUrl,
   createGitHubPlatformProvider,
   type GitHubPlatformDeps,
 } from './provider';

--- a/packages/pi-platform-github/src/provider.ts
+++ b/packages/pi-platform-github/src/provider.ts
@@ -71,10 +71,16 @@ export function isKnownServerUrl(serverUrl: string): boolean {
  * appropriate source (e.g. `github.context.serverUrl`) and passing it in.
  *
  * @param serverUrl - The platform server URL (e.g. 'https://github.com').
+ * @param apiUrl - Optional REST API base URL advertised by the runner
+ *   (e.g. `GITHUB_API_URL`). When provided, a URL ending in `/api/v1`
+ *   reliably identifies Forgejo/Gitea/Codeberg even when the server hostname
+ *   does not contain "forgejo"/"gitea"/"codeberg" (e.g. `forge.example.com`).
+ *   GitHub Enterprise uses `/api/v3` and GitHub.com uses `api.github.com`,
+ *   so this disambiguates self-hosted Forgejo from self-hosted GHE.
  * @returns The detected platform type.
  */
 // fallow-ignore-next-line complexity
-export function detectPlatform(serverUrl: string): PlatformType {
+export function detectPlatform(serverUrl: string, apiUrl?: string): PlatformType {
   if (!serverUrl) {
     throw new Error('detectPlatform requires a server URL, got an empty string.');
   }
@@ -98,6 +104,21 @@ export function detectPlatform(serverUrl: string): PlatformType {
     serverUrl === 'http://github.com'
   ) {
     return 'github';
+  }
+
+  // API-URL based detection for Forgejo/Gitea/Codeberg instances whose
+  // hostname does not contain "forgejo"/"gitea"/"codeberg" (e.g.
+  // `forge.example.com`, `git.company.internal`). Forgejo's REST API lives
+  // at `{server}/api/v1`, whereas GitHub Enterprise uses `/api/v3` and
+  // GitHub.com uses `api.github.com`. This is the most reliable signal
+  // available in the runner environment.
+  if (apiUrl) {
+    const normalizedApi = apiUrl.replace(/\/+$/, '');
+    if (normalizedApi.endsWith('/api/v1')) {
+      return normalizedApi.includes('codeberg') || serverUrl.includes('codeberg')
+        ? 'codeberg'
+        : 'forgejo';
+    }
   }
 
   // Unknown server URL — default to 'github' for self-hosted GitHub
@@ -229,6 +250,7 @@ export function createGitHubPlatformProvider(deps: GitHubPlatformDeps): Platform
     octokit,
     context: resolvedContext,
     logger,
+    platformType: type,
     ...(trigger !== undefined ? { trigger } : {}),
     ...(deps.branchNameTemplate !== undefined
       ? { branchNameTemplate: deps.branchNameTemplate }

--- a/packages/pi-platform-github/src/provider.ts
+++ b/packages/pi-platform-github/src/provider.ts
@@ -6,8 +6,10 @@
  * GitHub-compatible REST APIs and the same CI/CD environment variables
  * (GITHUB_* env vars), so a single implementation covers all of them.
  *
- * Platform detection is performed by the pure `detectPlatform(serverUrl)`
- * function, which is invoked at the call site (e.g. in `pi-action/run.ts`).
+ * The platform is selected explicitly via the `platform` input (action) /
+ * `--platform` flag (CLI), resolved by the pure {@link parsePlatformType}
+ * function. There is no hostname-based auto-detection — it was unreliable
+ * for distinguishing self-hosted Forgejo from self-hosted GitHub Enterprise.
  * Library code does not read environment variables directly.
  */
 
@@ -42,95 +44,50 @@ import type {
 } from './tools/get-workflow-run-logs';
 
 /**
- * Substring patterns that identify a recognized git host. Matches the
- * branches of {@link detectPlatform}.
+ * Resolve a user-supplied platform string into a {@link PlatformType}.
  *
- * Exported so frontends can warn when a user points at a
- * host that doesn't match any known pattern — `detectPlatform` silently
- * falls back to `'github'` for unrecognized hosts, so callers that want
- * to surface the fallback must check this predicate themselves.
- */
-const KNOWN_HOST_PATTERNS = ['codeberg', 'forgejo', 'gitea', 'github.com', '.github.'] as const;
-
-/**
- * Return `true` iff `serverUrl` matches a host pattern recognized by
- * {@link detectPlatform}. Pure — no environment access.
- */
-export function isKnownServerUrl(serverUrl: string): boolean {
-  if (!serverUrl) {
-    return false;
-  }
-  return KNOWN_HOST_PATTERNS.some(pattern => serverUrl.includes(pattern));
-}
-
-/**
- * Detect the current platform based on a server URL.
+ * The platform is an **explicit input** (action `platform` input / CLI
+ * `--platform` flag) rather than being auto-detected from the server URL.
+ * Hostname-based detection was removed because it could not reliably tell
+ * self-hosted Forgejo (e.g. `forge.example.com`) from self-hosted GitHub
+ * Enterprise, and the API-URL heuristic was fragile.
  *
- * Pure function — no environment access. Callers (typically the action/
- * CLI entry point) are responsible for reading the URL from the
- * appropriate source (e.g. `github.context.serverUrl`) and passing it in.
+ * Resolution rules (case-insensitive, whitespace-trimmed):
+ * - Empty / unset → `'github'` (the default — the most common platform).
+ * - `'github'` → `'github'`
+ * - `'codeberg'` → `'codeberg'`
+ * - `'forgejo'` or `'gitea'` → `'forgejo'` (Gitea is API-compatible with
+ *   Forgejo and shares the same job-level action-run URL format).
+ * - Any other value → `'github'`. When `onUnknown` is provided it is
+ *   invoked with the raw input so the caller (action/CLI) can surface a
+ *   warning before the silent fallback.
  *
- * @param serverUrl - The platform server URL (e.g. 'https://github.com').
- * @param apiUrl - Optional REST API base URL advertised by the runner
- *   (e.g. `GITHUB_API_URL`). When provided, a URL ending in `/api/v1`
- *   reliably identifies Forgejo/Gitea/Codeberg even when the server hostname
- *   does not contain "forgejo"/"gitea"/"codeberg" (e.g. `forge.example.com`).
- *   GitHub Enterprise uses `/api/v3` and GitHub.com uses `api.github.com`,
- *   so this disambiguates self-hosted Forgejo from self-hosted GHE.
- * @returns The detected platform type.
+ * Pure function — no environment access.
+ *
+ * @param raw - The raw platform input string (may be undefined/empty).
+ * @param onUnknown - Optional callback invoked with the raw input when it
+ *   does not match a known platform, so frontends can warn the user.
+ * @returns The resolved platform type.
  */
-// fallow-ignore-next-line complexity
-export function detectPlatform(serverUrl: string, apiUrl?: string): PlatformType {
-  if (!serverUrl) {
-    throw new Error('detectPlatform requires a server URL, got an empty string.');
-  }
-
-  // Check for known Forgejo/Gitea indicators
-  if (serverUrl.includes('codeberg')) {
-    return 'codeberg';
-  }
-  if (serverUrl.includes('forgejo') || serverUrl.includes('gitea')) {
-    return 'forgejo';
-  }
-
-  // github.com, GitHub Enterprise (any hostname), and self-hosted GHE.
-  // Self-hosted GitHub Enterprise instances use custom hostnames like
-  // github.company.internal or gh.internal.corp. We catch these with a
-  // broad match before falling through to the unknown-default below.
-  if (
-    serverUrl.includes('github.com') ||
-    serverUrl.includes('.github.') ||
-    serverUrl === 'https://github.com' ||
-    serverUrl === 'http://github.com'
-  ) {
+export function parsePlatformType(
+  raw: string | undefined,
+  onUnknown?: (raw: string) => void
+): PlatformType {
+  const normalized = (raw ?? '').trim().toLowerCase();
+  if (normalized === '' || normalized === 'github') {
     return 'github';
   }
-
-  // API-URL based detection for Forgejo/Gitea/Codeberg instances whose
-  // hostname does not contain "forgejo"/"gitea"/"codeberg" (e.g.
-  // `forge.example.com`, `git.company.internal`). Forgejo's REST API lives
-  // at `{server}/api/v1`, whereas GitHub Enterprise uses `/api/v3` and
-  // GitHub.com uses `api.github.com`. This is the most reliable signal
-  // available in the runner environment.
-  if (apiUrl) {
-    const normalizedApi = apiUrl.replace(/\/+$/, '');
-    if (normalizedApi.endsWith('/api/v1')) {
-      return normalizedApi.includes('codeberg') || serverUrl.includes('codeberg')
-        ? 'codeberg'
-        : 'forgejo';
-    }
+  if (normalized === 'forgejo' || normalized === 'gitea') {
+    return 'forgejo';
   }
-
-  // Unknown server URL — default to 'github' for self-hosted GitHub
-  // Enterprise and other GitHub-compatible hosts.
-  //
-  // Rationale: the vast majority of unrecognised hosts are corporate GHE
-  // or GHE-like proxies. Falling back to 'github' gives them correct
-  // platform semantics (GitHub-compatible REST API). Codeberg and Forgejo
-  // are already caught by the explicit checks above.
-  //
-  // Frontends that want to surface the silent fallback can call
-  // {@link isKnownServerUrl} to detect this branch.
+  if (normalized === 'codeberg') {
+    return 'codeberg';
+  }
+  // Unrecognized input — surface it (if the caller wants to warn) and
+  // fall back to the GitHub default so a typo never hard-fails the run.
+  if (onUnknown) {
+    onUnknown(raw ?? '');
+  }
   return 'github';
 }
 
@@ -140,17 +97,16 @@ export function detectPlatform(serverUrl: string, apiUrl?: string): PlatformType
  * - `https://github.com` (exact): Octokit's default `https://api.github.com`
  * - `*.github.com` (subdomain, e.g. `github.example.com`): also default
  * - Self-hosted GHE with custom hostname (e.g. `github.company.internal`):
- *   {@link detectPlatform} (co-located in this module) defaults to `'github'`
- *   for unrecognized hosts, so these are treated as GHES-specific: the REST
- *   API is at `{serverUrl}/api/v3`.
+ *   these don't match github.com or a known Forgejo/Gitea indicator, so
+ *   they fall through to the GHES default: the REST API is at
+ *   `{serverUrl}/api/v3`.
  * - Codeberg, Forgejo, Gitea: `{serverUrl}/api/v1`
  *
  * Returning `undefined` lets the SDK use its built-in `api.github.com`.
  *
- * Natural pair of {@link detectPlatform}: both are pure functions of
- * `serverUrl` with overlapping host pattern-matching, answering
- * complementary questions (platform *type* vs *API URL*). Kept co-located
- * to avoid drift when a new host is added.
+ * Note: this derives the REST API base URL from the server URL only (used
+ * by the CLI, which has no runner environment). Platform *type* selection
+ * is now an explicit input resolved by {@link parsePlatformType}.
  */
 export function apiBaseUrlFromServerUrl(serverUrl: string): string | undefined {
   if (!serverUrl) {
@@ -212,9 +168,10 @@ export interface GitHubPlatformDeps {
    */
   trigger?: string;
   /**
-   * Explicit platform type. Required — library code does not read
-   * environment variables. Use `detectPlatform(context.serverUrl)` at
-   * the call site to derive it from the server URL.
+   * Explicit platform type, resolved from the `platform` input / `--platform`
+   * flag via {@link parsePlatformType}. Required — library code does not read
+   * environment variables. Defaults to `'github'` at the call site when the
+   * input is unset.
    */
   platformType: PlatformType;
   /**

--- a/packages/pi-platform-github/src/types.ts
+++ b/packages/pi-platform-github/src/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Logger } from '@alexanderfortin/pi-orchestrator';
-import type { PlatformContext } from '@alexanderfortin/pi-orchestrator';
+import type { PlatformContext, PlatformType } from '@alexanderfortin/pi-orchestrator';
 
 // Re-export shared platform types from the orchestrator so consumers within
 // the GitHub module can import them from a single location.
@@ -74,6 +74,15 @@ export interface GitHubModuleDeps {
    * When provided, overrides the default template.
    */
   readonly branchNameTemplate?: string;
+  /**
+   * The detected platform type ('github' | 'codeberg' | 'forgejo').
+   *
+   * Used by helpers that need platform-specific behaviour (e.g.
+   * `buildActionRunUrl()` builds different URLs for Forgejo/Codeberg vs
+   * GitHub). Optional so unit tests can omit it and get the GitHub
+   * default; production code should always set it via the provider.
+   */
+  readonly platformType?: PlatformType;
 }
 
 /**

--- a/packages/pi-platform-github/tests/comments-helpers.spec.ts
+++ b/packages/pi-platform-github/tests/comments-helpers.spec.ts
@@ -24,14 +24,18 @@ function buildDeps(
     owner?: string;
     repo?: string;
     runId?: number;
+    runAttempt?: number;
     serverUrl?: string;
+    platformType?: import('@alexanderfortin/pi-orchestrator').PlatformType;
   } = {}
 ): GitHubModuleDeps {
   const {
     owner = 'test-owner',
     repo = 'test-repo',
     runId = 12345,
+    runAttempt,
     serverUrl = 'https://github.com',
+    platformType,
   } = overrides;
   return {
     octokit: {} as any,
@@ -42,6 +46,7 @@ function buildDeps(
       payload: {},
       serverUrl,
       runId,
+      ...(runAttempt !== undefined ? { runAttempt } : {}),
       workspace: '/tmp',
     },
     logger: {
@@ -51,6 +56,7 @@ function buildDeps(
       notice: () => {},
       error: () => {},
     },
+    ...(platformType !== undefined ? { platformType } : {}),
   };
 }
 
@@ -113,6 +119,61 @@ describe('buildActionRunUrl', () => {
 
   test('returns undefined when runId is missing (0)', () => {
     expect(buildActionRunUrl(buildDeps({ runId: 0 }))).toBeUndefined();
+  });
+
+  test('uses the short GitHub format when platformType is github (default)', () => {
+    const url = buildActionRunUrl(
+      buildDeps({ owner: 'alex', repo: 'ansible', runId: 36, platformType: 'github' })
+    );
+    expect(url).toBe('https://github.com/alex/ansible/actions/runs/36');
+  });
+
+  test('appends /jobs/0/attempt/1 for Forgejo (default attempt)', () => {
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 28,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      })
+    );
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
+  });
+
+  test('appends /jobs/0/attempt/{n} for Forgejo when runAttempt is set', () => {
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 28,
+        runAttempt: 3,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      })
+    );
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/3');
+  });
+
+  test('appends the job/attempt suffix for Codeberg too', () => {
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'me',
+        repo: 'mine',
+        runId: 5,
+        serverUrl: 'https://codeberg.org',
+        platformType: 'codeberg',
+      })
+    );
+    expect(url).toBe('https://codeberg.org/me/mine/actions/runs/5/jobs/0/attempt/1');
+  });
+
+  test('uses the short format when platformType is unset (backward compat)', () => {
+    const url = buildActionRunUrl(
+      buildDeps({ owner: 'me', repo: 'mine', runId: 10, serverUrl: 'https://forge.l3x.in' })
+    );
+    // No platformType → treated as GitHub → short URL, no job/attempt suffix.
+    expect(url).toBe('https://forge.l3x.in/me/mine/actions/runs/10');
   });
 });
 
@@ -276,5 +337,21 @@ describe('buildMetadataFooter', () => {
   test('uses default serverUrl when context.serverUrl is empty', () => {
     const footer = buildMetadataFooter(buildDeps({ serverUrl: '' }), undefined);
     expect(footer).toContain('https://github.com/test-owner/test-repo/actions/runs/12345');
+  });
+
+  test('builds the Forgejo job-level URL in the footer', () => {
+    const footer = buildMetadataFooter(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 28,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      }),
+      undefined
+    );
+    expect(footer).toBe(
+      '[View action run](https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1)'
+    );
   });
 });

--- a/packages/pi-platform-github/tests/comments-helpers.spec.ts
+++ b/packages/pi-platform-github/tests/comments-helpers.spec.ts
@@ -175,6 +175,34 @@ describe('buildActionRunUrl', () => {
     // No platformType → treated as GitHub → short URL, no job/attempt suffix.
     expect(url).toBe('https://forge.l3x.in/me/mine/actions/runs/10');
   });
+
+  test('falls back to attempt 1 for a NaN runAttempt (malformed env var)', () => {
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 28,
+        runAttempt: NaN,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      })
+    );
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
+  });
+
+  test('falls back to attempt 1 for a zero runAttempt', () => {
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 28,
+        runAttempt: 0,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      })
+    );
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-platform-github/tests/provider.spec.ts
+++ b/packages/pi-platform-github/tests/provider.spec.ts
@@ -91,6 +91,46 @@ describe('detectPlatform', () => {
     expect(detectPlatform('https://unknown.host')).toBe('github');
     expect(detectPlatform('https://another-unknown.host')).toBe('github');
   });
+
+  test('detects forgejo from /api/v1 API URL even when hostname is ambiguous', () => {
+    // forge.example.com has no "forgejo"/"gitea"/"codeberg" substring, so
+    // without the API-URL hint it would fall back to 'github'. The
+    // GITHUB_API_URL ending in /api/v1 reliably identifies Forgejo/Gitea.
+    expect(detectPlatform('https://forge.l3x.in', 'https://forge.l3x.in/api/v1')).toBe('forgejo');
+    expect(
+      detectPlatform('https://git.company.internal', 'https://git.company.internal/api/v1')
+    ).toBe('forgejo');
+  });
+
+  test('detects codeberg from /api/v1 API URL containing "codeberg"', () => {
+    expect(detectPlatform('https://codeberg.org', 'https://codeberg.org/api/v1')).toBe('codeberg');
+  });
+
+  test('keeps github when API URL ends in /api/v3 (self-hosted GHE)', () => {
+    expect(
+      detectPlatform('https://github.company.internal', 'https://github.company.internal/api/v3')
+    ).toBe('github');
+  });
+
+  test('keeps github when API URL is api.github.com', () => {
+    expect(detectPlatform('https://github.com', 'https://api.github.com')).toBe('github');
+  });
+
+  test('trailing slash on /api/v1 is handled', () => {
+    expect(detectPlatform('https://forge.l3x.in', 'https://forge.l3x.in/api/v1/')).toBe('forgejo');
+  });
+
+  test('explicit server-URL patterns take precedence over API URL', () => {
+    // A server URL that explicitly contains "forgejo" wins regardless of apiUrl.
+    expect(detectPlatform('https://forgejo.example.com', 'https://api.github.com')).toBe('forgejo');
+    // A server URL that explicitly contains "github.com" wins over /api/v1.
+    expect(detectPlatform('https://github.com', 'https://some.host/api/v1')).toBe('github');
+  });
+
+  test('ignores empty / undefined API URL', () => {
+    expect(detectPlatform('https://unknown.host', undefined)).toBe('github');
+    expect(detectPlatform('https://unknown.host', '')).toBe('github');
+  });
 });
 
 describe('isKnownServerUrl', () => {

--- a/packages/pi-platform-github/tests/provider.spec.ts
+++ b/packages/pi-platform-github/tests/provider.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for platform abstraction module.
  *
- * Tests platform detection, provider creation, and the module's
+ * Tests platform input parsing, provider creation, and the module's
  * public API surface.
  */
 
@@ -13,9 +13,8 @@ setupGitHubTestEnv({ envPathPrefix: 'gh-event-platform' });
 // Import after mocks are set up
 import type { PlatformProvider } from '@alexanderfortin/pi-orchestrator';
 import {
-  detectPlatform,
+  parsePlatformType,
   apiBaseUrlFromServerUrl,
-  isKnownServerUrl,
   createGitHubPlatformProvider,
 } from '@alexanderfortin/pi-platform-github';
 import type { GitHubPlatformDeps } from '@alexanderfortin/pi-platform-github';
@@ -44,149 +43,54 @@ function makeMockDeps(overrides?: Partial<GitHubPlatformDeps>): GitHubPlatformDe
   };
 }
 
-describe('detectPlatform', () => {
-  test('returns github for github.com server URL', () => {
-    expect(detectPlatform('https://github.com')).toBe('github');
+describe('parsePlatformType', () => {
+  test('defaults to github for empty / undefined input', () => {
+    expect(parsePlatformType('')).toBe('github');
+    expect(parsePlatformType(undefined)).toBe('github');
+    expect(parsePlatformType('   ')).toBe('github');
   });
 
-  test('throws when server URL is empty', () => {
-    expect(() => detectPlatform('')).toThrow(/requires a server URL/);
+  test('returns github for github', () => {
+    expect(parsePlatformType('github')).toBe('github');
   });
 
-  test('returns codeberg for codeberg.org server URL', () => {
-    expect(detectPlatform('https://codeberg.org')).toBe('codeberg');
+  test('returns codeberg for codeberg', () => {
+    expect(parsePlatformType('codeberg')).toBe('codeberg');
   });
 
-  test('returns forgejo for server URL containing forgejo', () => {
-    expect(detectPlatform('https://forgejo.example.com')).toBe('forgejo');
+  test('returns forgejo for forgejo', () => {
+    expect(parsePlatformType('forgejo')).toBe('forgejo');
   });
 
-  test('returns forgejo for server URL containing gitea', () => {
-    expect(detectPlatform('https://gitea.example.com')).toBe('forgejo');
+  test('returns forgejo for gitea (API-compatible alias)', () => {
+    expect(parsePlatformType('gitea')).toBe('forgejo');
   });
 
-  test('returns github for unknown non-github.com server URL (default fallback)', () => {
-    // Self-hosted GHE and other GitHub-compatible hosts default to 'github'
-    // instead of throwing. See detectPlatform docstring for rationale.
-    expect(detectPlatform('https://git.mycompany.com')).toBe('github');
+  test('is case-insensitive and trims whitespace', () => {
+    expect(parsePlatformType('Forgejo')).toBe('forgejo');
+    expect(parsePlatformType('  CODEBERG  ')).toBe('codeberg');
+    expect(parsePlatformType('\tGiteA\n')).toBe('forgejo');
   });
 
-  test('returns github for GitHub Enterprise-like URL with custom domain', () => {
-    expect(detectPlatform('https://github.mycompany.com')).toBe('github');
+  test('falls back to github for an unrecognized value', () => {
+    expect(parsePlatformType('gitlab')).toBe('github');
+    expect(parsePlatformType('bitbucket')).toBe('github');
+    expect(parsePlatformType('nonsense')).toBe('github');
   });
 
-  test('detects codeberg with subpath URL', () => {
-    expect(detectPlatform('https://codeberg.org/some/repo')).toBe('codeberg');
+  test('invokes onUnknown with the raw input for an unrecognized value', () => {
+    const received: string[] = [];
+    const result = parsePlatformType('gitlab', raw => received.push(raw));
+    expect(result).toBe('github');
+    expect(received).toEqual(['gitlab']);
   });
 
-  test('detects forgejo with nested subdomain', () => {
-    expect(detectPlatform('https://git.forgejo.internal.company.net')).toBe('forgejo');
-  });
-
-  test('detects gitea with trailing slash', () => {
-    expect(detectPlatform('https://gitea.example.com/')).toBe('forgejo');
-  });
-
-  test('returns github for unknown host (default fallback)', () => {
-    expect(detectPlatform('https://unknown.host')).toBe('github');
-    expect(detectPlatform('https://another-unknown.host')).toBe('github');
-  });
-
-  test('detects forgejo from /api/v1 API URL even when hostname is ambiguous', () => {
-    // forge.example.com has no "forgejo"/"gitea"/"codeberg" substring, so
-    // without the API-URL hint it would fall back to 'github'. The
-    // GITHUB_API_URL ending in /api/v1 reliably identifies Forgejo/Gitea.
-    expect(detectPlatform('https://forge.l3x.in', 'https://forge.l3x.in/api/v1')).toBe('forgejo');
-    expect(
-      detectPlatform('https://git.company.internal', 'https://git.company.internal/api/v1')
-    ).toBe('forgejo');
-  });
-
-  test('detects codeberg from /api/v1 API URL containing "codeberg"', () => {
-    expect(detectPlatform('https://codeberg.org', 'https://codeberg.org/api/v1')).toBe('codeberg');
-  });
-
-  test('keeps github when API URL ends in /api/v3 (self-hosted GHE)', () => {
-    expect(
-      detectPlatform('https://github.company.internal', 'https://github.company.internal/api/v3')
-    ).toBe('github');
-  });
-
-  test('keeps github when API URL is api.github.com', () => {
-    expect(detectPlatform('https://github.com', 'https://api.github.com')).toBe('github');
-  });
-
-  test('trailing slash on /api/v1 is handled', () => {
-    expect(detectPlatform('https://forge.l3x.in', 'https://forge.l3x.in/api/v1/')).toBe('forgejo');
-  });
-
-  test('explicit server-URL patterns take precedence over API URL', () => {
-    // A server URL that explicitly contains "forgejo" wins regardless of apiUrl.
-    expect(detectPlatform('https://forgejo.example.com', 'https://api.github.com')).toBe('forgejo');
-    // A server URL that explicitly contains "github.com" wins over /api/v1.
-    expect(detectPlatform('https://github.com', 'https://some.host/api/v1')).toBe('github');
-  });
-
-  test('ignores empty / undefined API URL', () => {
-    expect(detectPlatform('https://unknown.host', undefined)).toBe('github');
-    expect(detectPlatform('https://unknown.host', '')).toBe('github');
-  });
-});
-
-describe('isKnownServerUrl', () => {
-  test('returns true for github.com', () => {
-    expect(isKnownServerUrl('https://github.com')).toBe(true);
-  });
-
-  test('returns true for codeberg', () => {
-    expect(isKnownServerUrl('https://codeberg.org')).toBe(true);
-  });
-
-  test('returns true for forgejo', () => {
-    expect(isKnownServerUrl('https://forgejo.example.com')).toBe(true);
-  });
-
-  test('returns true for gitea', () => {
-    expect(isKnownServerUrl('https://gitea.example.com')).toBe(true);
-  });
-
-  test('returns true for self-hosted GHE matching .github.', () => {
-    expect(isKnownServerUrl('https://something.github.company')).toBe(true);
-    expect(isKnownServerUrl('https://github.company.internal')).toBe(true);
-  });
-
-  test("returns false for hosts only matched by detectPlatform's silent fallback", () => {
-    // detectPlatform returns 'github' for these via the unknown-host default,
-    // but isKnownServerUrl surfaces them as unrecognized so the CLI can warn.
-    expect(isKnownServerUrl('https://github.mycompany.com')).toBe(false);
-    expect(isKnownServerUrl('https://gh.internal.corp')).toBe(false);
-  });
-
-  test('returns false for an unrecognized host (GitLab/Bitbucket case)', () => {
-    expect(isKnownServerUrl('https://gitlab.com')).toBe(false);
-    expect(isKnownServerUrl('https://bitbucket.org')).toBe(false);
-    expect(isKnownServerUrl('https://git.mycompany.com')).toBe(false);
-  });
-
-  test('returns false for empty string', () => {
-    expect(isKnownServerUrl('')).toBe(false);
-  });
-
-  test('agrees with detectPlatform for hosts matched by explicit patterns', () => {
-    // detectPlatform also returns 'github' for unrecognized hosts via its
-    // silent fallback. isKnownServerUrl only returns true for hosts matched
-    // by explicit patterns (the cases above). The list below must NOT
-    // include fallback-only hosts like 'https://github.mycompany.com'.
-    const explicitMatch = [
-      'https://github.com',
-      'https://codeberg.org',
-      'https://forgejo.example.com',
-      'https://gitea.example.com',
-      'https://something.github.company', // matches '.github.' substring
-    ];
-    for (const url of explicitMatch) {
-      expect(isKnownServerUrl(url)).toBe(true);
+  test('does not invoke onUnknown for recognized values (including the empty default)', () => {
+    const calls: string[] = [];
+    for (const value of ['', undefined, 'github', 'forgejo', 'gitea', 'codeberg']) {
+      parsePlatformType(value, raw => calls.push(raw));
     }
+    expect(calls).toEqual([]);
   });
 });
 
@@ -337,7 +241,7 @@ describe('apiBaseUrlFromServerUrl', () => {
     );
   });
 
-  test('throws when server URL is empty (aligned with detectPlatform)', () => {
+  test('throws when server URL is empty', () => {
     expect(() => apiBaseUrlFromServerUrl('')).toThrow(
       /apiBaseUrlFromServerUrl requires a server URL/
     );


### PR DESCRIPTION
## Problem

On Forgejo (and Codeberg/Gitea), the "View action run" footer link pointed at the wrong URL. The action generated GitHub-format URLs (`/{owner}/{repo}/actions/runs/{runId}`), but Forgejo's web UI requires a job-level URL with attempt suffix:

- ❌ **before:** `https://forge.l3x.in/alex/ansible/actions/runs/36`
- ✅ **after:** `https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1`

There were **two root causes**:

### 1. `buildActionRunUrl` always used the GitHub URL format
The function unconditionally built `…/actions/runs/{runId}`, regardless of platform. Forgejo/Codeberg need `/jobs/{jobIndex}/attempt/{attempt}` appended or the link doesn't resolve.

### 2. Platform type was derived via fragile autodetection
`detectPlatform(serverUrl)` tried to guess the platform from hostname substrings, and a later attempt added an API-URL (`/api/v1`) heuristic. Neither could reliably tell self-hosted Forgejo (e.g. `forge.example.com`) from self-hosted GitHub Enterprise.

## Fix

**Platform-aware URL building** (`comments.ts`):
- `buildActionRunUrl` checks `deps.platformType`. For `'forgejo'`/`'codeberg'` it appends `/jobs/0/attempt/{n}` (job index `0` = first/only job, attempt from `GITHUB_RUN_ATTEMPT`, default `1`).
- GitHub keeps the short format.

**Explicit platform input — no more autodetection** (`provider.ts`, `run.ts`, `pi-cli`):
- `detectPlatform()` / `isKnownServerUrl()` / the `KNOWN_HOST_PATTERNS` table and the `GITHUB_API_URL` heuristic are **removed entirely**.
- The platform is now an **explicit input**: the action's `platform` input (default `github`) and the CLI's `--platform` flag (default `github`).
- A new pure helper `parsePlatformType(raw, onUnknown?)` resolves the input:
  - empty/unset → `github` (default)
  - `github` → `github`
  - `codeberg` → `codeberg`
  - `forgejo` / `gitea` → `forgejo` (API-compatible alias)
  - anything else → `github` (with an optional `onUnknown` warning so a typo never hard-fails)
- This is both simpler and more reliable than guessing from the hostname.

**Wiring** (`run.ts`):
- Reads the `platform` input (default `github`), warns on unknown values.
- Reads `GITHUB_RUN_ATTEMPT` into the new `PlatformContext.runAttempt` field.

**Threading** (`types.ts`, `provider.ts`):
- Optional `platformType` on `GitHubModuleDeps`; the provider threads it into the deps bag so `buildActionRunUrl` can read it.
- Optional `runAttempt` on `PlatformContext`.

## Changes

| File | Change |
|------|--------|
| `pi-orchestrator/.../platform/types.ts` | `+runAttempt?: number` on `PlatformContext` |
| `pi-platform-github/src/types.ts` | `+platformType?: PlatformType` on `GitHubModuleDeps` |
| `pi-platform-github/src/comments.ts` | `buildActionRunUrl` now platform-aware (Forgejo/Codeberg job-level URLs) |
| `pi-platform-github/src/provider.ts` | **Removed** `detectPlatform`/`isKnownServerUrl`/`KNOWN_HOST_PATTERNS`; added `parsePlatformType(raw, onUnknown?)`; threads `platformType` into deps |
| `pi-platform-github/src/index.ts` | Export `parsePlatformType` instead of `detectPlatform`/`isKnownServerUrl` |
| `pi-action/src/run.ts` | Reads the `platform` input (default `github`); reads `GITHUB_RUN_ATTEMPT` |
| `pi-cli/src/index.ts` | New `--platform` flag (default `github`) |
| `pi-cli/src/commands/run.ts` | Uses `parsePlatformType(args.platform)`; drops detect/isKnown usage |
| `action.yml`, `README.md`, `AGENTS.md` | Document the `platform` input; drop "platform detection" from `server_url` |
| `comments-helpers.spec.ts` | 6 new tests (Forgejo/Codeberg URL formats, backward compat) |
| `provider.spec.ts` | Replaced detectPlatform/isKnownServer suites with a `parsePlatformType` suite |

Fixes #341