### PR TITLE
fix: thread resolved platformType into CLI API base URL

### DIFF
--- a/packages/pi-cli/src/commands/run.ts
+++ b/packages/pi-cli/src/commands/run.ts
@@ -98,18 +98,22 @@ export async function runCommand(args: RunCommandArgs): Promise<void> {
 
   // --- Octokit + platform provider (setup error if --repo bad) --------
   const repo = parseRepoFlag(args.repo);
-  const octokit = createCliOctokit(githubToken, args.serverUrl);
-  const platformContext = buildPlatformContext({
-    repo,
-    workspace: args.cwd,
-    serverUrl: args.serverUrl,
-  });
+  // Resolve the platform type first so it can inform both the API base URL
+  // (createCliOctokit) and the provider (footer URL format). This lets
+  // --platform override hostname matching for self-hosted Forgejo hosts
+  // whose URL has no forgejo/codeberg/gitea indicator (e.g. forge.l3x.in).
   const platformType = parsePlatformType(args.platform, raw =>
     logger.warning(
       `Unknown platform '${raw}'; falling back to github. ` +
         `Valid values are github, codeberg, forgejo, or gitea.`
     )
   );
+  const octokit = createCliOctokit(githubToken, args.serverUrl, platformType);
+  const platformContext = buildPlatformContext({
+    repo,
+    workspace: args.cwd,
+    serverUrl: args.serverUrl,
+  });
   const provider = createGitHubPlatformProvider({
     octokit,
     context: platformContext,

--- a/packages/pi-cli/src/octokit.ts
+++ b/packages/pi-cli/src/octokit.ts
@@ -17,6 +17,7 @@
 import { Octokit } from '@octokit/core';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import type { OctokitInstance } from '@alexanderfortin/pi-platform-github/types';
+import type { PlatformType } from '@alexanderfortin/pi-orchestrator';
 import { apiBaseUrlFromServerUrl } from '@alexanderfortin/pi-platform-github';
 
 /**
@@ -33,9 +34,17 @@ export const OctokitWithRest = Octokit.plugin(restEndpointMethods);
  * @param token - GitHub API token (PAT or `GITHUB_TOKEN`).
  * @param serverUrl - Web URL of the git host (e.g. `https://github.com`).
  *                    Used to derive the API base URL for non-github.com hosts.
+ * @param platformType - Resolved platform type (from `--platform` flag). When
+ *                       forgejo/codeberg, forces `/api/v1` regardless of
+ *                       hostname so self-hosted Forgejo (e.g. `forge.l3x.in`)
+ *                       gets the correct API URL.
  */
-export function createCliOctokit(token: string, serverUrl: string): OctokitInstance {
-  const baseUrl = apiBaseUrlFromServerUrl(serverUrl);
+export function createCliOctokit(
+  token: string,
+  serverUrl: string,
+  platformType?: PlatformType
+): OctokitInstance {
+  const baseUrl = apiBaseUrlFromServerUrl(serverUrl, platformType);
   return new OctokitWithRest({
     auth: token,
     ...(baseUrl !== undefined ? { baseUrl } : {}),

--- a/packages/pi-cli/tests/commands/run-integration.spec.ts
+++ b/packages/pi-cli/tests/commands/run-integration.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * @file Integration tests for {@link runCommand} (the `pi-cli run` wiring).
+ *
+ * `runCommand` chains argv → token resolution → Octokit + platform provider
+ * → orchestrator. Its observable wiring is tested here by mocking the two
+ * side-effectful boundaries:
+ *
+ *   - `createCliPiAgent` (would invoke the LLM SDK) → a fake agent that
+ *     resolves immediately with a fixed result.
+ *   - `createCliOctokit` (constructs a real Octokit) → a spy that records its
+ *     arguments and returns a stub octokit.
+ *
+ * The CLI's sentinel platform context (`issue.number: 0`, empty payload,
+ * `'cli'` event name) makes the provider's reaction/comment methods no-op, so
+ * the stub octokit is never actually called. This lets us assert the pure
+ * wiring — in particular that the resolved `--platform` value is threaded to
+ * **both** the Octokit API base URL (`createCliOctokit`) **and** the platform
+ * provider (footer URL format) — without any network or LLM calls.
+ *
+ * `runCommand`'s end-to-end execution is what gives the platform-threading
+ * lines in `run.ts` their coverage; the unit behaviour of `createCliOctokit`
+ * and `parsePlatformType` is covered in their own spec files.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Module mocks — registered before any import of run.ts so its bindings pick
+// up the replacements. (Bun resolves mock.module against the absolute path of
+// the specifier, so the path here is relative to *this* test file.)
+// ---------------------------------------------------------------------------
+
+/** A recorded `createCliOctokit(token, serverUrl, platformType)` invocation. */
+interface CapturedOctokitCall {
+  token: string;
+  serverUrl: string;
+  platformType: string | undefined;
+}
+
+/**
+ * Captures every `createCliOctokit(token, serverUrl, platformType)` invocation
+ * so tests can assert the resolved `--platform` reaches the API-base-URL path.
+ */
+const octokitCalls: CapturedOctokitCall[] = [];
+
+// The CLI context never exercises octokit REST methods (reactions + comments
+// no-op for the 'cli' sentinel context), so an empty object is a safe stand-in.
+const stubOctokit = {};
+
+/**
+ * The single `createCliOctokit` call recorded for the current `runCommand`.
+ *
+ * `noUncheckedIndexedAccess` types `octokitCalls[0]` as possibly undefined;
+ * each `runCommand` issues exactly one call, so this both asserts that and
+ * returns a non-nullable reference for chained assertions.
+ */
+function singleOctokitCall(): CapturedOctokitCall {
+  expect(octokitCalls).toHaveLength(1);
+  return octokitCalls[0]!;
+}
+
+mock.module('../../src/octokit.js', () => ({
+  createCliOctokit: (token: string, serverUrl: string, platformType?: string) => {
+    octokitCalls.push({ token, serverUrl, platformType });
+    return stubOctokit;
+  },
+}));
+
+/**
+ * Most-recent platform-provider `type` handed to the Pi agent factory, so tests
+ * can assert the resolved `--platform` also reaches the provider (footer URL).
+ */
+let lastProviderType: string | undefined;
+
+const fakeRun = mock(() =>
+  Promise.resolve({ result: 'CLI agent finished', sessionStats: undefined, error: undefined })
+);
+
+mock.module('../../src/adapters/pi-agent.js', () => ({
+  createCliPiAgent: (_config: unknown, _logger: unknown, provider: { type?: string }) => {
+    lastProviderType = provider.type;
+    return {
+      run: () => fakeRun(),
+      getSessionStats: () => undefined,
+      exportSessionHtml: () => Promise.resolve(''),
+      exportSessionJsonl: () => Promise.resolve(''),
+    };
+  },
+}));
+
+// Import after the mocks above are registered.
+const { runCommand } = await import('../../src/commands/run.js');
+import type { RunCommandArgs } from '../../src/commands/run.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function makeArgs(overrides: Partial<RunCommandArgs> = {}): RunCommandArgs {
+  return {
+    prompt: 'say hello',
+    repo: 'shaftoe/pi-coding-agent-action',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    cwd: '/tmp/pi-cli-test',
+    serverUrl: 'https://forge.l3x.in',
+    platform: 'forgejo',
+    verbose: false,
+    quiet: false,
+    ...overrides,
+  };
+}
+
+const ENV_KEYS = ['GITHUB_TOKEN', 'GH_TOKEN', 'ANTHROPIC_API_KEY'] as const;
+let savedEnv: Record<string, string | undefined> = {};
+let savedExitCode: typeof process.exitCode;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+  }
+  process.env.GITHUB_TOKEN = 'ghp-test';
+  process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+  delete process.env.GH_TOKEN;
+  savedExitCode = process.exitCode;
+  process.exitCode = 0;
+
+  octokitCalls.length = 0;
+  lastProviderType = undefined;
+  fakeRun.mockClear();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+  process.exitCode = savedExitCode;
+});
+
+// ---------------------------------------------------------------------------
+// --platform threading (the behaviour this PR adds)
+// ---------------------------------------------------------------------------
+
+describe('runCommand — --platform threading', () => {
+  test('threads forgejo into both the API base URL and the provider', async () => {
+    // forge.l3x.in has no forgejo/codeberg/gitea hostname indicator, so the
+    // explicit --platform is what makes API calls hit /api/v1 (not /api/v3).
+    await runCommand(makeArgs({ platform: 'forgejo' }));
+
+    // API base-URL path (createCliOctokit)
+    const call = singleOctokitCall();
+    expect(call.serverUrl).toBe('https://forge.l3x.in');
+    expect(call.platformType).toBe('forgejo');
+    // Provider path (footer URL format)
+    expect(lastProviderType).toBe('forgejo');
+    // The (fake) agent ran exactly once → the orchestrator completed.
+    expect(fakeRun).toHaveBeenCalledTimes(1);
+  });
+
+  test('threads codeberg into both the API base URL and the provider', async () => {
+    await runCommand(makeArgs({ platform: 'codeberg' }));
+    expect(singleOctokitCall().platformType).toBe('codeberg');
+    expect(lastProviderType).toBe('codeberg');
+  });
+
+  test('resolves the gitea alias to forgejo end-to-end', async () => {
+    // parsePlatformType('gitea') → 'forgejo'; the CLI threads that resolved
+    // value, so API calls hit /api/v1 and the footer uses the Forgejo format.
+    await runCommand(makeArgs({ platform: 'gitea' }));
+    expect(singleOctokitCall().platformType).toBe('forgejo');
+    expect(lastProviderType).toBe('forgejo');
+  });
+
+  test('threads github into both paths (hostname matching)', async () => {
+    await runCommand(makeArgs({ platform: 'github', serverUrl: 'https://github.com' }));
+    const call = singleOctokitCall();
+    expect(call.serverUrl).toBe('https://github.com');
+    expect(call.platformType).toBe('github');
+    expect(lastProviderType).toBe('github');
+  });
+
+  test('defaults to github when --platform is empty', async () => {
+    await runCommand(makeArgs({ platform: '' }));
+    expect(singleOctokitCall().platformType).toBe('github');
+    expect(lastProviderType).toBe('github');
+  });
+
+  test('warns and falls back to github for an unknown --platform value', async () => {
+    // An unrecognized value invokes the onUnknown callback (logger.warning)
+    // inside runCommand's parsePlatformType call, then falls back to 'github'
+    // so a typo never hard-fails the run.
+    await runCommand(makeArgs({ platform: 'gitlab' }));
+    expect(singleOctokitCall().platformType).toBe('github');
+    expect(lastProviderType).toBe('github');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Setup errors short-circuit before the platform is even resolved
+// ---------------------------------------------------------------------------
+
+describe('runCommand — setup errors short-circuit before platform resolution', () => {
+  test('throws for an unknown --provider', async () => {
+    await expect(runCommand(makeArgs({ provider: 'nope' }))).rejects.toThrow(/Unknown provider/);
+    // createCliOctokit must not have run on a setup error.
+    expect(octokitCalls).toHaveLength(0);
+  });
+
+  test('throws for a malformed --repo', async () => {
+    await expect(runCommand(makeArgs({ repo: 'not-a-slug' }))).rejects.toThrow(/Expected format/);
+    expect(octokitCalls).toHaveLength(0);
+  });
+});

--- a/packages/pi-cli/tests/octokit.spec.ts
+++ b/packages/pi-cli/tests/octokit.spec.ts
@@ -41,4 +41,18 @@ describe('createCliOctokit', () => {
     // No network call: just confirm auth was wired (auth() returns the stored
     // token without making a request when only `type: 'token'` is used).
   });
+
+  it('uses /api/v1 for a forgejo host with no hostname indicator when platformType=forgejo', () => {
+    // forge.l3x.in has no forgejo/codeberg/gitea substring, so hostname
+    // matching alone would return /api/v3. The explicit platform override
+    // forces /api/v1 so API calls don't 404.
+    const octokit = createCliOctokit('fake-token', 'https://forge.l3x.in', 'forgejo');
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe('https://forge.l3x.in/api/v1');
+  });
+
+  it('still uses hostname matching when platformType is omitted', () => {
+    // Without the override, forge.l3x.in falls through to the /api/v3 default.
+    const octokit = createCliOctokit('fake-token', 'https://forge.l3x.in');
+    expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe('https://forge.l3x.in/api/v3');
+  });
 });

--- a/packages/pi-platform-github/src/provider.ts
+++ b/packages/pi-platform-github/src/provider.ts
@@ -104,15 +104,33 @@ export function parsePlatformType(
  *
  * Returning `undefined` lets the SDK use its built-in `api.github.com`.
  *
- * Note: this derives the REST API base URL from the server URL only (used
- * by the CLI, which has no runner environment). Platform *type* selection
- * is now an explicit input resolved by {@link parsePlatformType}.
+ * When `platformType` is explicitly `'forgejo'` or `'codeberg'`, the
+ * `/api/v1` suffix is used **regardless of hostname**. This lets callers
+ * that resolve the platform via an explicit input (CLI `--platform` flag)
+ * override the hostname-based heuristic, which cannot distinguish a
+ * self-hosted Forgejo instance (e.g. `forge.l3x.in`) from self-hosted GHE.
+ * When `platformType` is omitted or `'github'`, the hostname matching below
+ * is used as before.
+ *
+ * @param serverUrl - The platform web server URL.
+ * @param platformType - Optional resolved platform type. When forgejo/
+ *   codeberg, forces `/api/v1` suffix regardless of hostname.
  */
-export function apiBaseUrlFromServerUrl(serverUrl: string): string | undefined {
+export function apiBaseUrlFromServerUrl(
+  serverUrl: string,
+  platformType?: PlatformType
+): string | undefined {
   if (!serverUrl) {
     throw new Error('apiBaseUrlFromServerUrl requires a server URL, got an empty string.');
   }
   const url = serverUrl.replace(/\/$/, '');
+
+  // Explicit platform input overrides hostname matching. This is the
+  // reliable path for self-hosted Forgejo whose hostname has no
+  // forgejo/codeberg/gitea indicator (e.g. forge.l3x.in).
+  if (platformType === 'forgejo' || platformType === 'codeberg') {
+    return `${url}/api/v1`;
+  }
 
   // Exact github.com → Octokit's default.
   if (url === 'https://github.com') {

--- a/packages/pi-platform-github/tests/provider.spec.ts
+++ b/packages/pi-platform-github/tests/provider.spec.ts
@@ -246,4 +246,41 @@ describe('apiBaseUrlFromServerUrl', () => {
       /apiBaseUrlFromServerUrl requires a server URL/
     );
   });
+
+  // --- platformType override --------------------------------------------
+
+  test('platformType=forgejo forces /api/v1 regardless of hostname', () => {
+    // forge.l3x.in has no forgejo/codeberg/gitea indicator in its hostname,
+    // so hostname matching alone would return /api/v3 (wrong).
+    expect(apiBaseUrlFromServerUrl('https://forge.l3x.in', 'forgejo')).toBe(
+      'https://forge.l3x.in/api/v1'
+    );
+    expect(apiBaseUrlFromServerUrl('https://git.company.internal', 'forgejo')).toBe(
+      'https://git.company.internal/api/v1'
+    );
+  });
+
+  test('platformType=codeberg forces /api/v1 regardless of hostname', () => {
+    expect(apiBaseUrlFromServerUrl('https://example.com', 'codeberg')).toBe(
+      'https://example.com/api/v1'
+    );
+  });
+
+  test('platformType=github uses hostname matching (backward compat)', () => {
+    // Explicit github still uses the hostname-based logic below the override.
+    expect(apiBaseUrlFromServerUrl('https://github.com', 'github')).toBeUndefined();
+    expect(apiBaseUrlFromServerUrl('https://codeberg.org', 'github')).toBe(
+      'https://codeberg.org/api/v1'
+    );
+    expect(apiBaseUrlFromServerUrl('https://github.company.internal', 'github')).toBe(
+      'https://github.company.internal/api/v3'
+    );
+  });
+
+  test('platformType undefined uses hostname matching (backward compat)', () => {
+    expect(apiBaseUrlFromServerUrl('https://forge.l3x.in')).toBe('https://forge.l3x.in/api/v3');
+    expect(apiBaseUrlFromServerUrl('https://forge.l3x.in', undefined)).toBe(
+      'https://forge.l3x.in/api/v3'
+    );
+  });
 });


### PR DESCRIPTION
## Problem

Follow-up to #342 (review comment on `pi-cli/src/commands/run.ts`).

The CLI's `createCliOctokit` derived the Octokit **API base URL** purely from hostname matching (`apiBaseUrlFromServerUrl`), which returns `/api/v3` for self-hosted Forgejo hosts whose URL has no `forgejo`/`codeberg`/`gitea` indicator:

```ts
apiBaseUrlFromServerUrl('https://forge.l3x.in')
// → 'https://forge.l3x.in/api/v3'   ❌  (Forgejo uses /api/v1)
```

So `--platform forgejo --server-url https://forge.l3x.in` fixed the **footer URL** (via #342) but API calls would **404** on that exact host — the very instance that motivated the whole effort.

## Fix

Let the resolved `platformType` (from `--platform`) inform the API base URL, just like it already informs the footer URL:

- **`apiBaseUrlFromServerUrl`** now accepts an optional `platformType` parameter. When `'forgejo'`/`'codeberg'`, it forces `/api/v1` **regardless of hostname**. When omitted or `'github'`, hostname matching is used as before (fully backward compatible — `pi-action-bridge` and all existing callers are unaffected).
- **`createCliOctokit`** accepts and passes through `platformType`.
- **`runCommand`** resolves `platformType` first (via `parsePlatformType(args.platform)`), then passes it to `createCliOctokit` — so `--platform` works end-to-end: correct API URL **and** correct footer URL.

## Changes

| File | Change |
|------|--------|
| `pi-platform-github/src/provider.ts` | `apiBaseUrlFromServerUrl` accepts optional `platformType`; forgejo/codeberg → `/api/v1` override |
| `pi-cli/src/octokit.ts` | `createCliOctokit` accepts optional `platformType`, passes through |
| `pi-cli/src/commands/run.ts` | Resolves `platformType` before Octokit creation; threads it through |
| `provider.spec.ts` | 4 new tests (forgejo/codeberg override, github/undefined backward compat) |
| `octokit.spec.ts` | 2 new tests (platform override, hostname matching fallback) |

Stacked on top of #342. Once #342 merges to `develop`, retarget this PR to `develop`.