### PR TITLE
fix: thread platformType into the git adapter so the footer URL respects the platform

### DIFF
--- a/packages/pi-action/src/adapters/git-adapter.ts
+++ b/packages/pi-action/src/adapters/git-adapter.ts
@@ -13,7 +13,12 @@ import {
   getStartTimeFromContext,
   type GitHubModuleDeps,
 } from '@alexanderfortin/pi-platform-github';
-import type { GitAdapter, CommentMetadata, CoreAdapter } from '@alexanderfortin/pi-orchestrator';
+import type {
+  GitAdapter,
+  CommentMetadata,
+  CoreAdapter,
+  PlatformType,
+} from '@alexanderfortin/pi-orchestrator';
 
 /**
  * Production adapter for git hosting platform operations.
@@ -28,12 +33,14 @@ export class RealGitAdapter implements GitAdapter {
   constructor(
     private readonly core: CoreAdapter,
     octokit: GitHubModuleDeps['octokit'],
-    context: GitHubModuleDeps['context']
+    context: GitHubModuleDeps['context'],
+    platformType?: PlatformType
   ) {
     this.deps = {
       octokit,
       context,
       logger: core,
+      ...(platformType !== undefined ? { platformType } : {}),
     };
   }
 

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -138,8 +138,11 @@ export async function run() {
     ...(branchNameTemplate ? { branchNameTemplate } : {}),
   });
 
-  // Create the git adapter with explicit deps
-  const gitAdapter = new RealGitAdapter(coreAdapter, octokit, platformContext);
+  // Create the git adapter with explicit deps.
+  // platformType is threaded through so the footer URL builder
+  // (buildActionRunUrl) can pick the correct URL format for the
+  // target platform (e.g. Forgejo/Codeberg job-level URLs).
+  const gitAdapter = new RealGitAdapter(coreAdapter, octokit, platformContext, platformType);
 
   const orchestrator = new ActionOrchestrator(
     config,

--- a/packages/pi-action/tests/adapters/git-adapter.spec.ts
+++ b/packages/pi-action/tests/adapters/git-adapter.spec.ts
@@ -74,4 +74,70 @@ describe('RealGitAdapter', () => {
     const result = gitAdapter.getStartTime();
     expect(result).toBeUndefined();
   });
+
+  test('constructor accepts an optional platformType (forgejo)', () => {
+    expect(
+      () => new RealGitAdapter(createMockCoreAdapter(), mockOctokit as any, mockContext, 'forgejo')
+    ).not.toThrow();
+  });
+
+  test('createFinalComment threads platformType into deps so the footer uses the Forgejo URL format', async () => {
+    // Regression guard for the bug where RealGitAdapter dropped platformType,
+    // causing buildActionRunUrl to emit the bare GitHub URL even on Forgejo.
+    const created: { body: string }[] = [];
+    const forgejoOctokit = {
+      rest: {
+        issues: {
+          createComment: async (params: { body: string }) => {
+            created.push({ body: params.body });
+            return { data: {} };
+          },
+        },
+      },
+    };
+    const gitAdapter = new RealGitAdapter(
+      createMockCoreAdapter(),
+      forgejoOctokit as any,
+      mockContext,
+      'forgejo'
+    );
+    // createFinalComment on the adapter is fire-and-forget (void), so call the
+    // underlying module function directly with the same deps shape to assert
+    // the URL format. We verify via the adapter's own path by spying on the
+    // octokit call.
+    await gitAdapter.createFinalComment('hello', {
+      provider: 'p',
+      model: 'm',
+    });
+    expect(created).toHaveLength(1);
+    // Forgejo/Codeberg URLs include the /jobs/0/attempt/<n> suffix.
+    expect(created[0]!.body).toContain(
+      'https://github.com/test-owner/test-repo/actions/runs/123456789/jobs/0/attempt/1'
+    );
+  });
+
+  test('createFinalComment omits platformType when not provided, yielding the GitHub URL format', async () => {
+    const created: { body: string }[] = [];
+    const ghOctokit = {
+      rest: {
+        issues: {
+          createComment: async (params: { body: string }) => {
+            created.push({ body: params.body });
+            return { data: {} };
+          },
+        },
+      },
+    };
+    const gitAdapter = new RealGitAdapter(createMockCoreAdapter(), ghOctokit as any, mockContext);
+    await gitAdapter.createFinalComment('hello', {
+      provider: 'p',
+      model: 'm',
+    });
+    expect(created).toHaveLength(1);
+    // GitHub URL has no job/attempt suffix.
+    expect(created[0]!.body).toContain(
+      'https://github.com/test-owner/test-repo/actions/runs/123456789'
+    );
+    expect(created[0]!.body).not.toContain('/jobs/0/attempt/');
+  });
 });

--- a/packages/pi-action/tests/adapters/git-adapter.spec.ts
+++ b/packages/pi-action/tests/adapters/git-adapter.spec.ts
@@ -95,16 +95,17 @@ describe('RealGitAdapter', () => {
         },
       },
     };
+    // Use a Forgejo-style serverUrl so the asserted URL is self-documenting
+    // (a "forgejo" footer should not live under github.com).
+    const forgejoContext = { ...mockContext, serverUrl: 'https://codeberg.org' };
     const gitAdapter = new RealGitAdapter(
       createMockCoreAdapter(),
       forgejoOctokit as any,
-      mockContext,
+      forgejoContext,
       'forgejo'
     );
-    // createFinalComment on the adapter is fire-and-forget (void), so call the
-    // underlying module function directly with the same deps shape to assert
-    // the URL format. We verify via the adapter's own path by spying on the
-    // octokit call.
+    // Exercises the full RealGitAdapter → createFinalComment → buildActionRunUrl
+    // path by capturing the body posted to octokit.rest.issues.createComment.
     await gitAdapter.createFinalComment('hello', {
       provider: 'p',
       model: 'm',
@@ -112,7 +113,7 @@ describe('RealGitAdapter', () => {
     expect(created).toHaveLength(1);
     // Forgejo/Codeberg URLs include the /jobs/0/attempt/<n> suffix.
     expect(created[0]!.body).toContain(
-      'https://github.com/test-owner/test-repo/actions/runs/123456789/jobs/0/attempt/1'
+      'https://codeberg.org/test-owner/test-repo/actions/runs/123456789/jobs/0/attempt/1'
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #345.

The `platform` input (`forgejo`/`codeberg`) was being parsed correctly and handed to the **platform provider**, but the "View action run" footer is posted through a different path: the orchestrator's **git adapter** (`RealGitAdapter`), which never received `platformType`. So `buildActionRunUrl(deps)` evaluated `deps.platformType === 'forgejo'` → `undefined === 'forgejo'` → `false`, and the footer always emitted the bare GitHub-style URL even on Forgejo/Codeberg.

This is a localized, two-line fix that threads `platformType` into the git-adapter path, so the footer renders the correct job-level URL (e.g. `…/actions/runs/<id>/jobs/0/attempt/1`) for Forgejo/Codeberg.

## Changes

- **`packages/pi-action/src/adapters/git-adapter.ts`** — `RealGitAdapter` now accepts an optional `platformType` and includes it in `this.deps`:
  ```ts
  this.deps = {
    octokit,
    context,
    logger: core,
    ...(platformType !== undefined ? { platformType } : {}),
  };
  ```
- **`packages/pi-action/src/run.ts`** — pass `platformType` through to the adapter:
  ```ts
  const gitAdapter = new RealGitAdapter(coreAdapter, octokit, platformContext, platformType);
  ```
- **`packages/pi-action/tests/adapters/git-adapter.spec.ts`** — added regression tests exercising the previously-untested `RealGitAdapter → createFinalComment → buildActionRunUrl` path:
  - with `platformType: 'forgejo'` → footer URL contains `/jobs/0/attempt/1`
  - without `platformType` → footer URL is the bare GitHub format (no job/attempt suffix)

## Why the suite missed it

The existing unit test in `comments-helpers.spec.ts` handed `platformType` directly to the deps, so it passed — but nothing exercised the production adapter path where the value was silently dropped. The new tests cover exactly that gap.

## Notes

- The `dist/index.js` bundle has been rebuilt and carries the verified version stamp (`2.23.0-develop.af7b6ce`).
- `bun run validate` (lint + type-check + prettier) passes, and all 1648 tests pass.
- I chose option 1 from the issue (threading `platformType` into the git adapter) as it is the smaller, more targeted fix. The alternative (routing the final comment through `this.platformProvider.createFinalComment(…)`) would be a larger change to the orchestrator.