### PR TITLE
fix: use runNumber (not runId) for Forgejo "View action run" footer link

### DIFF
--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -95,14 +95,6 @@ export async function run() {
     );
   }
 
-  // GITHUB_RUN_ATTEMPT is 1 for the first run and increments on re-runs.
-  // Forgejo/Codeberg action-run URLs include it as an /attempt/{n} segment.
-  // Guard against malformed values (NaN/0) that would bypass the ?? 1
-  // fallback in buildActionRunUrl.
-  const runAttemptNum = Number(process.env.GITHUB_RUN_ATTEMPT);
-  const runAttempt =
-    Number.isFinite(runAttemptNum) && runAttemptNum > 0 ? runAttemptNum : undefined;
-
   const platformContext = {
     repo: github.context.repo,
     issue: { number: issueNumber },
@@ -110,7 +102,7 @@ export async function run() {
     payload,
     serverUrl,
     runId: github.context.runId,
-    ...(runAttempt !== undefined ? { runAttempt } : {}),
+    runNumber: github.context.runNumber,
     workspace: process.env.GITHUB_WORKSPACE ?? process.cwd(),
     ...(githubCtx.actor !== undefined ? { actor: githubCtx.actor } : {}),
     ...(githubCtx.sha !== undefined ? { sha: githubCtx.sha } : {}),

--- a/packages/pi-action/tests/adapters/git-adapter.spec.ts
+++ b/packages/pi-action/tests/adapters/git-adapter.spec.ts
@@ -97,7 +97,14 @@ describe('RealGitAdapter', () => {
     };
     // Use a Forgejo-style serverUrl so the asserted URL is self-documenting
     // (a "forgejo" footer should not live under github.com).
-    const forgejoContext = { ...mockContext, serverUrl: 'https://codeberg.org' };
+    // runId (44) and runNumber (36) differ: Forgejo serves the run at the
+    // per-repo run NUMBER, so the footer must use 36, not 44.
+    const forgejoContext = {
+      ...mockContext,
+      serverUrl: 'https://codeberg.org',
+      runId: 44,
+      runNumber: 36,
+    };
     const gitAdapter = new RealGitAdapter(
       createMockCoreAdapter(),
       forgejoOctokit as any,
@@ -111,10 +118,10 @@ describe('RealGitAdapter', () => {
       model: 'm',
     });
     expect(created).toHaveLength(1);
-    // Forgejo/Codeberg URLs include the /jobs/0/attempt/<n> suffix.
-    expect(created[0]!.body).toContain(
-      'https://codeberg.org/test-owner/test-repo/actions/runs/123456789/jobs/0/attempt/1'
-    );
+    // Forgejo/Codeberg URLs use the per-repo runNumber, no job/attempt suffix.
+    expect(created[0]!.body).toContain('https://codeberg.org/test-owner/test-repo/actions/runs/36');
+    expect(created[0]!.body).not.toContain('/jobs/');
+    expect(created[0]!.body).not.toContain('/runs/44');
   });
 
   test('createFinalComment omits platformType when not provided, yielding the GitHub URL format', async () => {

--- a/packages/pi-orchestrator/src/platform/types.ts
+++ b/packages/pi-orchestrator/src/platform/types.ts
@@ -45,14 +45,18 @@ export interface PlatformContext {
    */
   runId?: number;
   /**
-   * The current workflow run attempt number (1 for the first attempt,
-   * incrementing on each re-run). Read from `GITHUB_RUN_ATTEMPT`.
+   * The current workflow run NUMBER (the per-repo sequence, read from
+   * `GITHUB_RUN_NUMBER`).
    *
-   * Optional so non-CI frontends can omit it; `buildActionRunUrl()`
-   * defaults to `1` when absent. Used by Forgejo/Codeberg whose
-   * action-run URLs include an `/attempt/{n}` segment.
+   * This is distinct from {@link runId}, which is the global DB id.
+   * Forgejo/Codeberg serve an action run at `…/actions/runs/{runNumber}`
+   * — using `runId` there produces a 404 — so `buildActionRunUrl()` reads
+   * this field for the Forgejo/Codeberg URL. GitHub itself uses `runId` in
+   * its URLs and ignores this field.
+   *
+   * Optional so non-CI frontends (e.g. the CLI) can omit it.
    */
-  runAttempt?: number;
+  runNumber?: number;
   /** The workspace directory path */
   workspace: string;
   /** The user/actor who triggered the workflow (e.g. for Co-authored-by trailers). */

--- a/packages/pi-platform-github/src/comments.ts
+++ b/packages/pi-platform-github/src/comments.ts
@@ -47,12 +47,16 @@ export type CreateCommentType =
  *
  * URL formats differ by platform:
  * - **GitHub** (incl. GitHub Enterprise): `{server}/{owner}/{repo}/actions/runs/{runId}`
- * - **Forgejo / Codeberg / Gitea**: `{server}/{owner}/{repo}/actions/runs/{runId}/jobs/{jobIndex}/attempt/{attempt}`
+ * - **Forgejo / Codeberg / Gitea**: `{server}/{owner}/{repo}/actions/runs/{runNumber}`
  *
- * Forgejo's web UI requires the job-level suffix (`/jobs/0/attempt/1`) — the
- * bare run URL does not resolve. The job index defaults to `0` (the first —
- * and typically only — job in a workflow that uses this action). The attempt
- * number comes from `context.runAttempt` (defaults to `1`).
+ * Forgejo serves an action run at the **per-repo run NUMBER**, not the global
+ * run id — the two are different values, and `GITHUB_RUN_ID` (what `runId`
+ * holds) 404s when substituted into Forgejo's URL. The canonical `html_url`
+ * Forgejo's own API returns is the bare run URL with no job/attempt suffix.
+ *
+ * GitHub itself uses `GITHUB_RUN_ID` in its URLs, so the runNumber override is
+ * scoped to the Forgejo/Codeberg branch only. When `runNumber` is missing on a
+ * Forgejo-like platform, we fall back to `runId` as a best-effort baseline.
  */
 // fallow-ignore-next-line complexity
 export function buildActionRunUrl(deps: GitHubModuleDeps): string | undefined {
@@ -64,15 +68,18 @@ export function buildActionRunUrl(deps: GitHubModuleDeps): string | undefined {
   }
   const baseUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
 
-  // Forgejo/Codeberg/Gitea require a job-level URL with an attempt segment.
+  // Forgejo/Codeberg serve the run at the per-repo run NUMBER, not the
+  // global run id. Using runId here would 404; the canonical URL has no
+  // job/attempt suffix.
   const isForgejoLike = deps.platformType === 'forgejo' || deps.platformType === 'codeberg';
   if (isForgejoLike) {
-    // Defensive guard: a malformed runAttempt (NaN/0) would otherwise
-    // slip past the default and produce an invalid /attempt/NaN URL.
-    const rawAttempt = deps.context.runAttempt;
-    const attempt =
-      rawAttempt !== undefined && Number.isFinite(rawAttempt) && rawAttempt > 0 ? rawAttempt : 1;
-    return `${baseUrl}/jobs/0/attempt/${attempt}`;
+    const runNumber = deps.context.runNumber;
+    if (!runNumber) {
+      // Graceful fallback: runNumber missing — emit the runId baseline.
+      // Only correct for GitHub, but better than suppressing the footer.
+      return baseUrl;
+    }
+    return `${serverUrl}/${owner}/${repo}/actions/runs/${runNumber}`;
   }
 
   return baseUrl;

--- a/packages/pi-platform-github/tests/comments-helpers.spec.ts
+++ b/packages/pi-platform-github/tests/comments-helpers.spec.ts
@@ -24,7 +24,7 @@ function buildDeps(
     owner?: string;
     repo?: string;
     runId?: number;
-    runAttempt?: number;
+    runNumber?: number;
     serverUrl?: string;
     platformType?: import('@alexanderfortin/pi-orchestrator').PlatformType;
   } = {}
@@ -33,7 +33,7 @@ function buildDeps(
     owner = 'test-owner',
     repo = 'test-repo',
     runId = 12345,
-    runAttempt,
+    runNumber,
     serverUrl = 'https://github.com',
     platformType,
   } = overrides;
@@ -46,7 +46,7 @@ function buildDeps(
       payload: {},
       serverUrl,
       runId,
-      ...(runAttempt !== undefined ? { runAttempt } : {}),
+      ...(runNumber !== undefined ? { runNumber } : {}),
       workspace: '/tmp',
     },
     logger: {
@@ -128,80 +128,59 @@ describe('buildActionRunUrl', () => {
     expect(url).toBe('https://github.com/alex/ansible/actions/runs/36');
   });
 
-  test('appends /jobs/0/attempt/1 for Forgejo (default attempt)', () => {
+  test('uses runNumber (not runId) for Forgejo, with no job/attempt suffix', () => {
+    // Regression guard: Forgejo serves a run at the per-repo run NUMBER.
+    // runId (44) and runNumber (36) differ; using runId would 404.
     const url = buildActionRunUrl(
       buildDeps({
         owner: 'alex',
         repo: 'ansible',
-        runId: 28,
+        runId: 44,
+        runNumber: 36,
         serverUrl: 'https://forge.l3x.in',
         platformType: 'forgejo',
       })
     );
-    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/36');
+    // No job/attempt suffix — Forgejo's canonical html_url is the bare run URL.
+    expect(url).not.toContain('/jobs/');
   });
 
-  test('appends /jobs/0/attempt/{n} for Forgejo when runAttempt is set', () => {
-    const url = buildActionRunUrl(
-      buildDeps({
-        owner: 'alex',
-        repo: 'ansible',
-        runId: 28,
-        runAttempt: 3,
-        serverUrl: 'https://forge.l3x.in',
-        platformType: 'forgejo',
-      })
-    );
-    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/3');
-  });
-
-  test('appends the job/attempt suffix for Codeberg too', () => {
+  test('uses runNumber for Codeberg too, with no suffix', () => {
     const url = buildActionRunUrl(
       buildDeps({
         owner: 'me',
         repo: 'mine',
-        runId: 5,
+        runId: 50,
+        runNumber: 5,
         serverUrl: 'https://codeberg.org',
         platformType: 'codeberg',
       })
     );
-    expect(url).toBe('https://codeberg.org/me/mine/actions/runs/5/jobs/0/attempt/1');
+    expect(url).toBe('https://codeberg.org/me/mine/actions/runs/5');
+  });
+
+  test('falls back to runId when runNumber is missing on Forgejo', () => {
+    // Graceful fallback: without runNumber we emit the runId baseline.
+    // Only correct for GitHub, but better than suppressing the footer.
+    const url = buildActionRunUrl(
+      buildDeps({
+        owner: 'alex',
+        repo: 'ansible',
+        runId: 44,
+        serverUrl: 'https://forge.l3x.in',
+        platformType: 'forgejo',
+      })
+    );
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/44');
   });
 
   test('uses the short format when platformType is unset (backward compat)', () => {
     const url = buildActionRunUrl(
       buildDeps({ owner: 'me', repo: 'mine', runId: 10, serverUrl: 'https://forge.l3x.in' })
     );
-    // No platformType → treated as GitHub → short URL, no job/attempt suffix.
+    // No platformType → treated as GitHub → short URL, no runNumber override.
     expect(url).toBe('https://forge.l3x.in/me/mine/actions/runs/10');
-  });
-
-  test('falls back to attempt 1 for a NaN runAttempt (malformed env var)', () => {
-    const url = buildActionRunUrl(
-      buildDeps({
-        owner: 'alex',
-        repo: 'ansible',
-        runId: 28,
-        runAttempt: NaN,
-        serverUrl: 'https://forge.l3x.in',
-        platformType: 'forgejo',
-      })
-    );
-    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
-  });
-
-  test('falls back to attempt 1 for a zero runAttempt', () => {
-    const url = buildActionRunUrl(
-      buildDeps({
-        owner: 'alex',
-        repo: 'ansible',
-        runId: 28,
-        runAttempt: 0,
-        serverUrl: 'https://forge.l3x.in',
-        platformType: 'forgejo',
-      })
-    );
-    expect(url).toBe('https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1');
   });
 });
 
@@ -367,19 +346,18 @@ describe('buildMetadataFooter', () => {
     expect(footer).toContain('https://github.com/test-owner/test-repo/actions/runs/12345');
   });
 
-  test('builds the Forgejo job-level URL in the footer', () => {
+  test('builds the Forgejo run URL (runNumber, no suffix) in the footer', () => {
     const footer = buildMetadataFooter(
       buildDeps({
         owner: 'alex',
         repo: 'ansible',
-        runId: 28,
+        runId: 44,
+        runNumber: 36,
         serverUrl: 'https://forge.l3x.in',
         platformType: 'forgejo',
       }),
       undefined
     );
-    expect(footer).toBe(
-      '[View action run](https://forge.l3x.in/alex/ansible/actions/runs/28/jobs/0/attempt/1)'
-    );
+    expect(footer).toBe('[View action run](https://forge.l3x.in/alex/ansible/actions/runs/36)');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #341 (for real this time — the `b528cc` fix in #340 targeted the wrong thing).

The "View action run" footer link pointed at a **404 on every Forgejo/Codeberg run** because Forgejo serves an action run at the **per-repo run NUMBER** (`GITHUB_RUN_NUMBER`), but the action built the URL from the **global run ID** (`GITHUB_RUN_ID`). These are different values (e.g. `runId=44` vs `runNumber=36` on the affected repo), and the offset varies per repo — so the link never resolved.

The previous fix (`b528cc`) appended a `/jobs/0/attempt/1` suffix, which was a red herring: Forgejo's canonical `html_url` has **no suffix at all**, and the base number was still wrong. This PR fixes the actual root cause.

## Changes

- **`pi-orchestrator/src/platform/types.ts`** — replaced the now-unused `runAttempt?: number` field with `runNumber?: number` on `PlatformContext`, with docs explaining the distinction from `runId`.
- **`pi-platform-github/src/comments.ts`** — `buildActionRunUrl()` now uses `context.runNumber` for the Forgejo/Codeberg URL and drops the `/jobs/0/attempt/{n}` suffix entirely. GitHub keeps using `runId` (correct for github.com/GHE). Falls back to the `runId` baseline when `runNumber` is missing.
- **`pi-action/src/run.ts`** — carries `github.context.runNumber` into the platform context; removed the dead `GITHUB_RUN_ATTEMPT` parsing.
- **Tests** — updated the Forgejo/Codeberg assertions to expect the bare `runs/{runNumber}` URL (e.g. `runs/36`, not `runs/44/jobs/0/attempt/1`), added a regression guard that `runId ≠ runNumber`, and verified the graceful fallback when `runNumber` is absent.

## Result

For the run in the issue, the footer will now resolve to:
```
https://forge.l3x.in/alex/ansible/actions/runs/36
```
instead of the dead `…/runs/44[/jobs/0/attempt/1]`.

## Validation

- `bun run validate` ✅ (ESLint, type-check, Prettier)
- `bun test` ✅ (1646 pass, 0 fail)
- `bun run fallow:dead-code` ✅ (no issues — the removed `runAttempt` field left no dead code)

`dist/index.js` is intentionally not touched — it's rebuilt via the automated `chore(dist)` step post-merge.