### PR TITLE
fix(share): propagate OPENGIST_TOKEN through reusable workflow + drop harmful opengist token crossover

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -21,3 +21,4 @@ jobs:
     secrets:
       gh_token: ${{ secrets.GH_PAT }} # Has Gists write access
       token: ${{ secrets.API_KEY }}
+      opengist_token: ${{ secrets.OPENGIST_TOKEN }}

--- a/.github/workflows/pi.yml
+++ b/.github/workflows/pi.yml
@@ -14,6 +14,12 @@ on:
         required: true
       gh_token:
         required: true
+      opengist_token:
+        # Opengist access token (og_…) used by the opengist share provider.
+        # Must be declared here so callers can pass it through — reusable
+        # workflows only see secrets listed under `workflow_call.secrets`, so
+        # an undeclared `secrets.OPENGIST_TOKEN` silently resolves to empty.
+        required: false
 
 permissions:
   contents: write
@@ -52,7 +58,7 @@ jobs:
           share_session: true
           share_gist_provider: opengist
           share_gist_api_url: https://gist.l3x.in/api/gists
-          share_gist_token: ${{ secrets.OPENGIST_TOKEN }}
+          share_gist_token: ${{ secrets.opengist_token }}
           github_token: ${{ secrets.gh_token }}
           provider: ${{ vars.PROVIDER }}
           model: ${{ vars.MODEL }}

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ The pi.dev viewer **cannot** read non-GitHub gists (it hardcodes `api.github.com
 Notes:
 - The Opengist REST API create endpoint is `POST <instance>/api/gists`. Create an access token in **Settings → Access Tokens** (it starts with `og_`) and grant it the `gist:write` scope. See the [Opengist API docs](https://opengist.io/docs).
 - Gists are created as `unlisted` (not listed publicly, but readable via the unguessable URL) — the closest analogue of a GitHub "secret" gist.
-- `share_gist_token` is optional: when unset, the action falls back to `github_token`, so you can reuse a single token if your Opengist setup accepts it.
+- `share_gist_token` is required for the opengist provider (an `og_…` access token with `gist:write` scope). Unlike the `github` provider, there is **no fallback to `github_token`** — a GitHub token can never authenticate against a self-hosted Opengist instance, so without `share_gist_token` the share is skipped with a clear notice.
 - The `share_url` uses the gist's **raw route** (`<gist page>/raw/HEAD/session.html`), which Opengist serves as `text/html` so the self-contained session renders directly in a browser. The `HEAD` revision resolves to the latest commit (see the [Opengist docs](https://opengist.io/docs)). Because this raw-route behaviour is instance-specific, **verify it after upgrading Opengist** by creating a shared session and opening the link in a fresh browser — if your version doesn't accept `HEAD` on the raw route, share links will 404.
 - Set `PI_SHARE_VIEWER_URL` to a custom (non-pi.dev) viewer to instead build a `<viewer>#<gistPageUrl>` link that a self-hosted viewer can render (see [Custom viewer](#custom-viewer)).
 
@@ -734,7 +734,7 @@ For complex, multi-step tasks that generate a lot of context (e.g. large code re
 | `share_session` | Share the session like pi's `/share` command: upload the exported HTML to a gist and surface a viewer link. Uses GitHub Gists by default (`share_gist_provider: github`) or a self-hosted Opengist instance. Auto-enables `export_session_html` | No | `false` |
 | `share_gist_provider` | Storage backend for `share_session`: `github` (GitHub Gists + pi.dev viewer) or `opengist` (self-hosted instance; requires `share_gist_api_url`) | No | `github` |
 | `share_gist_api_url` | API URL for the share gist provider. Required for `opengist` (e.g. `https://gist.l3x.in/api/gists`); optional override for `github` | No | - |
-| `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist`; falls back to `github_token` | No | - |
+| `share_gist_token` | Token used to create the shared gist. Opengist access token (`og_…`, `gist:write` scope) for `opengist` (required — no `github_token` fallback); optional GitHub PAT for the `github` provider (falls back to `github_token`) | No | - |
 | `server_url` | Override the forge server URL (e.g. `https://git.example.com`) when the runner-advertised `GITHUB_SERVER_URL` points at an internally-reachable host (e.g. `http://localhost:3000` on a Forgejo runner behind Docker). Affects user-facing links (commits, PRs, action runs) only — the API client keeps using the runner's `GITHUB_API_URL`, and platform selection is controlled by the `platform` input. | No | - |
 | `thinking_level` | Model thinking level | No | off |
 | `token` | Provider API token. Required for most providers, but can be omitted when using providers that support alternative auth mechanisms (e.g., `google-vertex` with Application Default Credentials) | No | - |

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ inputs:
     default: ''
 
   share_gist_token:
-    description: 'Token used to create the shared gist. For opengist, an Opengist access token (og_…) with the gist:write scope. Falls back to github_token when unset, so the github provider keeps working with a single token.'
+    description: 'Token used to create the shared gist. For opengist, an Opengist access token (og_…) with the gist:write scope — this is required (there is no github_token fallback, since a GitHub token cannot authenticate against a self-hosted Opengist instance). For the github provider, falls back to github_token when unset, so it keeps working with a single token.'
     required: false
     default: ''
 

--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -329,11 +329,17 @@ export class ActionOrchestrator {
     const tag = 'session-share';
     const token = resolveShareToken(this.config);
     if (!token) {
-      this.logger.notice(
-        `[${tag}] skipped: no share token configured ` +
-          '(provide a PAT/App token with gist scope via github_token, ' +
-          'or an Opengist access token via share_gist_token)'
-      );
+      // Branch the hint on the provider so the notice only mentions the
+      // credential that can actually authenticate against it. The opengist
+      // provider has no github_token fallback (a GitHub token can never
+      // authenticate against a self-hosted Opengist instance), so leading
+      // with "via github_token" there would be the very crossover this code
+      // path is meant to avoid.
+      const hint =
+        this.config.shareGistProvider === 'opengist'
+          ? 'provide an Opengist access token (og_…) via share_gist_token'
+          : 'provide a PAT/App token with gist scope via github_token (or share_gist_token)';
+      this.logger.notice(`[${tag}] skipped: no share token configured (${hint})`);
       return;
     }
 

--- a/packages/pi-orchestrator/src/share/provider.ts
+++ b/packages/pi-orchestrator/src/share/provider.ts
@@ -42,13 +42,19 @@ export function resolveGistProvider(config: ShareProviderConfig): GistProvider {
 
 /**
  * Resolve the token used to create the shared gist, picking the credential
- * that matches the selected provider and only crossing over when the
- * preferred token is absent.
+ * that matches the selected provider.
  *
- * - **opengist** prefers `shareGistToken` (an `og_…` token), falling back to
- *   `githubToken`.
+ * - **opengist** uses `shareGistToken` (an `og_…` access token) only. There is
+ *   **no** crossover to `githubToken`: a GitHub token can never authenticate
+ *   against a self-hosted Opengist instance (it expects its own `og_` tokens),
+ *   so crossing over would silently send `Bearer ghp_…` and produce a
+ *   confusing `401 Bad credentials` that masks the real misconfiguration (a
+ *   missing/unpropagated opengist token). When `shareGistToken` is absent,
+ *   `undefined` is returned so the orchestrator logs the clear "no share token
+ *   configured" notice instead.
  * - **github** (default) prefers `githubToken`, falling back to
- *   `shareGistToken`.
+ *   `shareGistToken` (which may legitimately hold a GitHub PAT for gist
+ *   creation when `github_token` isn't set).
  *
  * This provider-aware selection prevents mismatched combos — e.g. an `og_`
  * Opengist token being sent to `api.github.com`, or a `ghp_` GitHub token
@@ -56,9 +62,13 @@ export function resolveGistProvider(config: ShareProviderConfig): GistProvider {
  * failures, while keeping the single-`github_token` GitHub workflow intact.
  */
 export function resolveShareToken(config: ShareProviderConfig): string | undefined {
-  const isOpengist = config.shareGistProvider === 'opengist';
-  const primary = isOpengist ? config.shareGistToken : config.githubToken;
-  const fallback = isOpengist ? config.githubToken : config.shareGistToken;
+  if (config.shareGistProvider === 'opengist') {
+    /* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional ||: an empty-string token must collapse to undefined (it would fail auth) */
+    return config.shareGistToken || undefined;
+  }
+  // GitHub provider: prefer githubToken, fall back to shareGistToken.
+  const primary = config.githubToken;
+  const fallback = config.shareGistToken;
   /* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional ||: an empty-string token must fall through to the fallback (a "" token would fail auth) */
   return primary || fallback;
 }

--- a/packages/pi-orchestrator/src/types.ts
+++ b/packages/pi-orchestrator/src/types.ts
@@ -260,8 +260,9 @@ export interface PiConfig extends DiffConfig {
   shareGistApiUrl?: string;
   /**
    * Token used to create the shared gist. For Opengist, an access token
-   * (`og_…`) with the `gist:write` scope. Falls back to {@link githubToken}
-   * when unset, so the GitHub path keeps working with a single token.
+   * (`og_…`) with the `gist:write` scope — required for the opengist provider
+   * (there is no {@link githubToken} fallback). For the GitHub provider,
+   * falls back to {@link githubToken} when unset, so a single token suffices.
    */
   shareGistToken?: string;
   /** Override the default system prompt. */

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1778,28 +1778,25 @@ describe('ActionOrchestrator', () => {
       );
     });
 
-    test('uses githubToken as the share token fallback for Opengist', async () => {
-      globalThis.fetch = mock(async () => ({
-        ok: true,
-        status: 201,
-        json: async () => ({
-          id: 'og-uuid',
-          html_url: 'https://gist.l3x.in/bot/s',
-        }),
-        text: async () => '',
-      })) as unknown as typeof fetch;
-
+    test('does not fall back to githubToken for Opengist (would always 401)', async () => {
+      // A GitHub token can never authenticate against a self-hosted Opengist
+      // instance, so the opengist provider must NOT cross over to githubToken.
+      // With no shareGistToken the share is skipped with a clear notice instead
+      // of sending `Bearer ghp_…` and producing a confusing `401 Bad credentials`.
       const orchestrator = createOrchestrator({
         shareSession: true,
         shareGistProvider: 'opengist',
         shareGistApiUrl: 'https://gist.l3x.in/api/gists',
-        // shareGistToken unset — should fall back to githubToken
+        // shareGistToken intentionally unset — must NOT fall back to githubToken
         githubToken: 'ghp_fallback',
       });
       await orchestrator.execute();
 
-      const init = (globalThis.fetch as any).mock.calls[0][1];
-      expect(init.headers.Authorization).toBe('Bearer ghp_fallback');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(mockOutputSink.setOutput).not.toHaveBeenCalledWith('share_url', expect.anything());
+      expect(mockCore.notice).toHaveBeenCalledWith(
+        expect.stringContaining('no share token configured')
+      );
     });
   });
 });

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -1794,9 +1794,14 @@ describe('ActionOrchestrator', () => {
 
       expect(globalThis.fetch).not.toHaveBeenCalled();
       expect(mockOutputSink.setOutput).not.toHaveBeenCalledWith('share_url', expect.anything());
+      // The notice must lead with the opengist-specific hint (share_gist_token)
+      // and must NOT mention github_token — a GitHub token can never
+      // authenticate against a self-hosted Opengist instance.
       expect(mockCore.notice).toHaveBeenCalledWith(
         expect.stringContaining('no share token configured')
       );
+      expect(mockCore.notice).toHaveBeenCalledWith(expect.stringContaining('via share_gist_token'));
+      expect(mockCore.notice).not.toHaveBeenCalledWith(expect.stringContaining('via github_token'));
     });
   });
 });

--- a/packages/pi-orchestrator/tests/share/provider.spec.ts
+++ b/packages/pi-orchestrator/tests/share/provider.spec.ts
@@ -39,10 +39,14 @@ describe('resolveShareToken', () => {
     ).toBe('og_123');
   });
 
-  test('falls back to githubToken for opengist when shareGistToken is unset', () => {
-    expect(resolveShareToken({ shareGistProvider: 'opengist', githubToken: 'ghp_456' })).toBe(
-      'ghp_456'
-    );
+  test('returns undefined for opengist when shareGistToken is unset (no github crossover)', () => {
+    // A GitHub token can never authenticate against a self-hosted Opengist
+    // instance, so falling back to githubToken would only produce a confusing
+    // `401 Bad credentials`. Returning undefined yields the clear "no share
+    // token configured" notice instead.
+    expect(
+      resolveShareToken({ shareGistProvider: 'opengist', githubToken: 'ghp_456' })
+    ).toBeUndefined();
   });
 
   test('prefers githubToken over shareGistToken for the github provider', () => {
@@ -69,8 +73,14 @@ describe('resolveShareToken', () => {
     expect(resolveShareToken({})).toBeUndefined();
   });
 
-  test('ignores an empty shareGistToken and falls back', () => {
-    expect(resolveShareToken({ shareGistToken: '', githubToken: 'ghp_456' })).toBe('ghp_456');
+  test('ignores an empty shareGistToken for opengist and returns undefined', () => {
+    expect(
+      resolveShareToken({
+        shareGistProvider: 'opengist',
+        shareGistToken: '',
+        githubToken: 'ghp_456',
+      })
+    ).toBeUndefined();
   });
 
   test('ignores an empty githubToken and crosses over to shareGistToken for github', () => {


### PR DESCRIPTION
## Root cause

The `share_session` Opengist upload failed with `401 Unauthorized — {"message":"Bad crendentials","status":401}` (run [#28448495360](https://github.com/shaftoe/pi-coding-agent-action/actions/runs/28448495360)).

The `OPENGIST_TOKEN` secret **never reached the action** due to GitHub Actions reusable-workflow secret propagation rules:

1. `comment.yml` (triggered on issue/PR comments) calls the reusable workflow `pi.yml`, passing only `gh_token` + `token`.
2. `pi.yml` declares only `token` + `gh_token` under `workflow_call.secrets`, but the action step referenced the **undeclared** `secrets.OPENGIST_TOKEN`.
3. In a reusable workflow, an undeclared secret resolves to an **empty string** — confirmed live (`INPUT_SHARE_GIST_TOKEN` is empty in the action runtime).
4. With `share_gist_token` empty, `resolveShareToken()` fell back to `github_token` (a GitHub PAT).
5. Opengist received `Bearer ghp_…` (a token it can't validate) → `401 Bad crendentials`.

## Fix

### 1. Workflow secret propagation (the actual bug)

- **`.github/workflows/pi.yml`** — declare `opengist_token` (optional) under `workflow_call.secrets` and reference it as `secrets.opengist_token` (reusable workflows can only see declared secrets).
- **`.github/workflows/comment.yml`** — pass `opengist_token: ${{ secrets.OPENGIST_TOKEN }}` through to `pi.yml`.

### 2. Drop the opengist→github_token token crossover (defensive)

`resolveShareToken()` used to cross over from an empty `shareGistToken` to `githubToken` for the opengist provider. A GitHub token can **never** authenticate against a self-hosted Opengist instance (it expects its own `og_` tokens), so this crossover could only ever produce a confusing `401 Bad credentials` that masks the real misconfiguration. Now the opengist provider returns `undefined` when `shareGistToken` is absent, yielding the clear, actionable notice:

> `[session-share] skipped: no share token configured (provide ... an Opengist access token via share_gist_token)`

The `github` provider still falls back to `shareGistToken` (which may legitimately hold a GitHub PAT) — only the always-invalid opengist→github crossover was removed.

## Files

- `.github/workflows/pi.yml` — declare + reference `opengist_token` secret
- `.github/workflows/comment.yml` — pass the secret through
- `packages/pi-orchestrator/src/share/provider.ts` — remove opengist token crossover
- `packages/pi-orchestrator/src/types.ts` — clarify JSDoc
- `action.yml` / `README.md` — correct the "falls back to github_token" docs for opengist
- Tests updated to assert the new (skip-with-notice) behaviour

Closes #352.