### PR TITLE
fix: improve create_pull_request Forgejo compatibility with API URL fix and compare-URL fallback

### DIFF
--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -88,7 +88,7 @@ export async function run() {
       : undefined;
   const octokit = github.getOctokit(
     coreAdapter.getInput('github_token'),
-    ...(apiBaseUrl ? [{ baseUrl: apiBaseUrl }] : [])
+    apiBaseUrl ? { baseUrl: apiBaseUrl } : {}
   );
 
   // Build PlatformContext from the @actions/github singleton

--- a/packages/pi-action/src/run.ts
+++ b/packages/pi-action/src/run.ts
@@ -18,6 +18,7 @@ import { ActionsOutputSink } from './adapters/output-sink';
 import {
   createGitHubPlatformProvider,
   parsePlatformType,
+  apiBaseUrlFromServerUrl,
 } from '@alexanderfortin/pi-platform-github';
 import { resolveServerUrl } from './server-url';
 
@@ -58,8 +59,37 @@ export async function run() {
   const config = gatherActionsConfig();
   const outputSink = new ActionsOutputSink();
 
-  // Create Octokit from the github_token input
-  const octokit = github.getOctokit(coreAdapter.getInput('github_token'));
+  // Resolve the platform type early — it's needed for both the Octokit API
+  // base URL derivation (below) and the platform provider.
+  const platformType = parsePlatformType(coreAdapter.getInput('platform'), raw =>
+    coreAdapter.warning(
+      `Unknown platform "${raw}"; falling back to github. ` +
+        'Valid values are github, codeberg, forgejo (or gitea).'
+    )
+  );
+
+  // Create Octokit from the github_token input.
+  //
+  // For Forgejo/Codeberg we explicitly derive the API base URL from the
+  // runner-advertised server URL (ensuring the /api/v1 prefix is present).
+  // @actions/github's getOctokit() falls back to GITHUB_API_URL, which is
+  // reliable on GitHub but may be missing or misconfigured (no /api/v1) on
+  // some Forgejo runner versions — leading to 404s on every REST call.
+  //
+  // We use the runner-advertised server URL (github.context.serverUrl), not
+  // the server_url *override*, because the API must be reachable from inside
+  // the runner — the override is for externally-visible permalinks only.
+  //
+  // For GitHub (including GHES) we let getOctokit use GITHUB_API_URL as-is.
+  const runnerServerUrl = resolveServerUrl(undefined, github.context.serverUrl);
+  const apiBaseUrl =
+    platformType === 'forgejo' || platformType === 'codeberg'
+      ? apiBaseUrlFromServerUrl(runnerServerUrl, platformType)
+      : undefined;
+  const octokit = github.getOctokit(
+    coreAdapter.getInput('github_token'),
+    ...(apiBaseUrl ? [{ baseUrl: apiBaseUrl }] : [])
+  );
 
   // Build PlatformContext from the @actions/github singleton
   const githubCtx = github.context as { actor?: string; sha?: string };
@@ -111,16 +141,6 @@ export async function run() {
   // Create the platform provider with explicit deps (no singletons)
   const triggerValue = coreAdapter.getInput('trigger');
   const branchNameTemplate = coreAdapter.getInput('branch_name_template');
-  // Platform is an explicit input (default: github). It is no longer
-  // auto-detected from the server URL — hostname-based detection could
-  // not reliably distinguish self-hosted Forgejo from self-hosted GitHub
-  // Enterprise, so users set `platform` directly (e.g. forgejo).
-  const platformType = parsePlatformType(coreAdapter.getInput('platform'), raw =>
-    coreAdapter.warning(
-      `Unknown platform "${raw}"; falling back to github. ` +
-        'Valid values are github, codeberg, forgejo (or gitea).'
-    )
-  );
   const platformProvider = createGitHubPlatformProvider({
     octokit,
     context: platformContext,

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -21,7 +21,7 @@ export const CREATE_PULL_REQUEST_PROMPT_GUIDELINES = [
   'The tool will automatically generate a branch name in the format: pi/issue{number}-{timestamp}.',
   'Do NOT provide the "base" parameter unless the user explicitly requests a different target branch than the repository default. The tool will automatically detect the correct default branch.',
   'Use dryRun=true first to verify the PR configuration, then dryRun=false to create it.',
-  'On some platforms (e.g. Forgejo) the PR object cannot always be opened automatically even though the branch is pushed. When this happens the tool returns a compare URL instead of an error — post that URL so the user can open the PR with one click.',
+  'On some platforms (e.g. Forgejo) the PR object cannot always be opened automatically even though the branch is pushed. When this happens the tool returns a compare URL instead of an error — post that URL so the user can open the PR manually.',
 ];
 
 export const CREATE_PULL_REQUEST_DESCRIPTION =

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -21,6 +21,7 @@ export const CREATE_PULL_REQUEST_PROMPT_GUIDELINES = [
   'The tool will automatically generate a branch name in the format: pi/issue{number}-{timestamp}.',
   'Do NOT provide the "base" parameter unless the user explicitly requests a different target branch than the repository default. The tool will automatically detect the correct default branch.',
   'Use dryRun=true first to verify the PR configuration, then dryRun=false to create it.',
+  'On some platforms (e.g. Forgejo) the PR object cannot always be opened automatically even though the branch is pushed. When this happens the tool returns a compare URL instead of an error — post that URL so the user can open the PR with one click.',
 ];
 
 export const CREATE_PULL_REQUEST_DESCRIPTION =

--- a/packages/pi-orchestrator/src/platform/types.ts
+++ b/packages/pi-orchestrator/src/platform/types.ts
@@ -163,6 +163,22 @@ export interface CreatePullRequestDetails {
   baseBranch: string;
   dryRun: boolean;
   cancelled?: boolean;
+  /**
+   * `false` when the branch was created and pushed successfully but the PR
+   * object could not be opened (e.g. token lacks `pull-requests: write`
+   * on Forgejo). When `false`, {@link compareUrl} provides a manual-open
+   * link and {@link pullRequestUrl} is empty.
+   *
+   * Absent (or `true`) on the normal success path for backward
+   * compatibility.
+   */
+  prCreated?: boolean;
+  /**
+   * Compare URL for manually opening a PR when automatic creation failed
+   * (e.g. `{serverUrl}/{owner}/{repo}/compare/{base}...{head}`).
+   * Present only when {@link prCreated} is `false`.
+   */
+  compareUrl?: string;
 }
 
 export interface UpdatePullRequestParams {

--- a/packages/pi-orchestrator/src/platform/types.ts
+++ b/packages/pi-orchestrator/src/platform/types.ts
@@ -164,13 +164,11 @@ export interface CreatePullRequestDetails {
   dryRun: boolean;
   cancelled?: boolean;
   /**
-   * `false` when the branch was created and pushed successfully but the PR
-   * object could not be opened (e.g. token lacks `pull-requests: write`
-   * on Forgejo). When `false`, {@link compareUrl} provides a manual-open
-   * link and {@link pullRequestUrl} is empty.
-   *
-   * Absent (or `true`) on the normal success path for backward
-   * compatibility.
+   * `true` on the normal success path; `false` when the branch was created
+   * and pushed successfully but the PR object could not be opened (e.g.
+   * token lacks `pull-requests: write` on Forgejo). When `false`,
+   * {@link compareUrl} provides a manual-open link and
+   * {@link pullRequestUrl} is empty.
    */
   prCreated?: boolean;
   /**

--- a/packages/pi-platform-github/src/index.ts
+++ b/packages/pi-platform-github/src/index.ts
@@ -65,6 +65,10 @@ export {
   buildCreateDryRunResult,
   buildCreateSuccessMessage,
   buildCreateSuccessResult,
+  buildCreateFallbackMessage,
+  buildCreateFallbackResult,
+  buildCompareUrl,
+  getErrorStatus,
   formatCreateError,
 } from './tools/pull-request';
 

--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -383,12 +383,121 @@ export function formatCreateError(error: unknown): string {
 }
 
 /**
- * Prepare the branch, commit and PR on GitHub via the API. Wraps the
- * sequence `getRef → buildFileMap → scanForChanges → createRef →
+ * Extract the HTTP status code from an Octokit-style error object.
+ *
+ * Octokit errors carry a numeric `.status` property (e.g. 404, 403).
+ *
+ * @returns The status number, or `undefined` when not available.
+ * @internal Exported for testing purposes.
+ */
+export function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = error.status;
+    if (typeof status === 'number') {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a compare URL for manually opening a pull request.
+ *
+ * Format: `{serverUrl}/{owner}/{repo}/compare/{base}...{head}`
+ * Works across GitHub, Forgejo, Codeberg, and Gitea.
+ *
+ * @param deps - Module dependencies.
+ * @param baseBranch - Target (base) branch name.
+ * @param headBranch - Source (head) branch name.
+ * @returns The compare URL.
+ * @internal Exported for testing purposes.
+ */
+export function buildCompareUrl(
+  deps: GitHubModuleDeps,
+  baseBranch: string,
+  headBranch: string
+): string {
+  const { owner, repo } = deps.context.repo;
+  const serverUrl = (deps.context.serverUrl || 'https://github.com').replace(/\/$/, '');
+  return `${serverUrl}/${owner}/${repo}/compare/${baseBranch}...${headBranch}`;
+}
+
+/**
+ * Build the human-readable fallback message when the branch was created
+ * and pushed but the PR object could not be opened automatically. Includes
+ * a one-click compare URL so the user (or agent) can open the PR manually.
+ *
+ * Exported for unit testing.
+ */
+export function buildCreateFallbackMessage(
+  baseBranch: string,
+  headBranch: string,
+  compareUrl: string,
+  errorMessage: string
+): string {
+  return (
+    `Branch "${headBranch}" was created and pushed successfully, but the pull request ` +
+    `could not be opened automatically: ${errorMessage}\n\n` +
+    `You can open the PR with one click:\n${compareUrl}`
+  );
+}
+
+/**
+ * Build the structured result for a fallback (branch created, PR not opened).
+ * Exported for unit testing.
+ */
+export function buildCreateFallbackResult(
+  message: string,
+  headBranch: string,
+  baseBranch: string,
+  compareUrl: string
+): CreatePullRequestResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    details: {
+      pullRequestNumber: 0,
+      pullRequestUrl: '',
+      headBranch,
+      baseBranch,
+      dryRun: false,
+      prCreated: false,
+      compareUrl,
+    },
+  };
+}
+
+/**
+ * Result of preparing a branch and attempting to open a PR.
+ *
+ * When `pr` is present the PR was created successfully. When `prError` is
+ * present the branch was created and pushed but the PR object could not be
+ * opened (e.g. the token has push access but lacks `pull-requests: write`
+ * on Forgejo). The caller should provide a compare-URL fallback in that case.
+ */
+interface PrepareBranchAndPRResult {
+  /** The PR object when creation succeeded. */
+  pr?: GitHubPullRequestResult;
+  /** Error details when PR creation failed (branch was still created). */
+  prError?: { status: number | undefined; message: string };
+}
+
+/**
+ * Prepare the branch and commit on GitHub via the API, then attempt to open
+ * a pull request.
+ *
+ * Wraps the sequence `getRef → buildFileMap → scanForChanges → createRef →
  * createBlobsAndTree → createCommitAndUpdateBranch → createPullRequestOnGitHub`
  * into a single step.
  *
- * Throws `Error` when no changes are detected relative to the base branch.
+ * The branch/tree/commit operations and the `pulls.create` call are
+ * intentionally separated: git-data operations (refs, blobs, trees,
+ * commits) can succeed with push-only tokens, while `pulls.create` requires
+ * `pull-requests: write`. On Forgejo the ephemeral Actions token sometimes
+ * has the former but not the latter, so we catch the PR-creation error and
+ * return a structured result instead of throwing.
+ *
+ * Throws `Error` only when branch/commit creation itself fails (e.g. no
+ * changes detected, API error on git-data endpoints).
  */
 async function prepareBranchAndCreatePR(
   deps: GitHubModuleDeps,
@@ -397,7 +506,7 @@ async function prepareBranchAndCreatePR(
   title: string,
   bodyText: string,
   log: ReturnType<typeof createLogger>
-): Promise<GitHubPullRequestResult> {
+): Promise<PrepareBranchAndPRResult> {
   const owner = deps.context.repo.owner;
   const repo = deps.context.repo.repo;
 
@@ -452,7 +561,23 @@ async function prepareBranchAndCreatePR(
     log,
   });
 
-  return createPullRequestOnGitHub(deps, title, bodyText, baseBranch, head);
+  // Open the PR — this can fail independently of branch creation (e.g.
+  // the token has push access but lacks pull-requests: write on Forgejo).
+  // Catch the error and return a structured result so the caller can
+  // provide a compare-URL fallback instead of a raw throw.
+  try {
+    const pr = await createPullRequestOnGitHub(deps, title, bodyText, baseBranch, head);
+    return { pr };
+  } catch (error) {
+    const status = getErrorStatus(error);
+    const message = error instanceof Error ? error.message : String(error);
+    log.warning(
+      `PR creation failed after branch "${head}" was pushed ` +
+        `(HTTP ${status ?? 'unknown'}): ${message}. ` +
+        `The branch is ready — a compare URL will be provided.`
+    );
+    return { prError: { status, message } };
+  }
 }
 
 async function createPullRequestOnGitHub(
@@ -534,10 +659,32 @@ export async function createPullRequest(
   log.debug(`Preparing branch and changes via GitHub API...`);
 
   try {
-    const prResult = await prepareBranchAndCreatePR(deps, baseBranch, head, title, bodyText, log);
-    const successMessage = buildCreateSuccessMessage(prResult);
-    log.info(`SUCCESS: ${successMessage}`);
-    return buildCreateSuccessResult(prResult);
+    const result = await prepareBranchAndCreatePR(deps, baseBranch, head, title, bodyText, log);
+
+    // PR was created successfully
+    if (result.pr) {
+      const successMessage = buildCreateSuccessMessage(result.pr);
+      log.info(`SUCCESS: ${successMessage}`);
+      return buildCreateSuccessResult(result.pr);
+    }
+
+    // Branch was created and pushed but the PR object could not be opened
+    // (e.g. token lacks pull-requests:write on Forgejo). Provide a compare
+    // URL so the user or agent can open the PR manually.
+    if (result.prError) {
+      const compareUrl = buildCompareUrl(deps, baseBranch, head);
+      const message = buildCreateFallbackMessage(
+        baseBranch,
+        head,
+        compareUrl,
+        result.prError.message
+      );
+      log.info(`PARTIAL SUCCESS: ${message}`);
+      return buildCreateFallbackResult(message, head, baseBranch, compareUrl);
+    }
+
+    // Defensive — should never reach here
+    throw new Error('prepareBranchAndCreatePR returned neither pr nor prError');
   } catch (error) {
     throw new Error(formatCreateError(error));
   }

--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -369,6 +369,7 @@ export function buildCreateSuccessResult(pr: GitHubPullRequestResult): CreatePul
       headBranch: pr.headRef,
       baseBranch: pr.baseRef,
       dryRun: false,
+      prCreated: true,
     },
   };
 }
@@ -438,7 +439,7 @@ export function buildCreateFallbackMessage(
   return (
     `Branch "${headBranch}" was created and pushed successfully, but the pull request ` +
     `could not be opened automatically: ${errorMessage}\n\n` +
-    `You can open the PR with one click:\n${compareUrl}`
+    `You can open the PR manually here:\n${compareUrl}`
   );
 }
 
@@ -493,11 +494,14 @@ interface PrepareBranchAndPRResult {
  * intentionally separated: git-data operations (refs, blobs, trees,
  * commits) can succeed with push-only tokens, while `pulls.create` requires
  * `pull-requests: write`. On Forgejo the ephemeral Actions token sometimes
- * has the former but not the latter, so we catch the PR-creation error and
- * return a structured result instead of throwing.
+ * has the former but not the latter, so we catch **only** 401/403
+ * (permission) errors from `pulls.create` and return a structured result
+ * instead of throwing. All other errors (422 already-exists, 5xx, etc.)
+ * are re-thrown so they are not silently masked as partial success.
  *
- * Throws `Error` only when branch/commit creation itself fails (e.g. no
- * changes detected, API error on git-data endpoints).
+ * Throws `Error` when branch/commit creation itself fails (e.g. no changes
+ * detected, API error on git-data endpoints) or when PR creation fails with
+ * a non-permission HTTP status.
  */
 async function prepareBranchAndCreatePR(
   deps: GitHubModuleDeps,
@@ -563,17 +567,32 @@ async function prepareBranchAndCreatePR(
 
   // Open the PR — this can fail independently of branch creation (e.g.
   // the token has push access but lacks pull-requests: write on Forgejo).
-  // Catch the error and return a structured result so the caller can
-  // provide a compare-URL fallback instead of a raw throw.
+  //
+  // We only fall back to a compare URL for token-permission failures
+  // (401/403), which is the Forgejo scenario this targets. Other errors
+  // are re-thrown so they surface to the agent/user rather than being
+  // silently masked as partial success:
+  //   - 422 "A pull request already exists" (e.g. action re-run) → the
+  //     agent should use update_pull_request instead of opening a PR
+  //     that already exists.
+  //   - 5xx / transient network errors → the agent should be able to
+  //     retry or report the real failure.
   try {
     const pr = await createPullRequestOnGitHub(deps, title, bodyText, baseBranch, head);
     return { pr };
   } catch (error) {
     const status = getErrorStatus(error);
     const message = error instanceof Error ? error.message : String(error);
+    if (status !== 401 && status !== 403) {
+      log.debug(
+        `PR creation failed with HTTP ${status ?? 'unknown'} (not a ` +
+          `permission error) — re-throwing after branch "${head}" was pushed.`
+      );
+      throw error;
+    }
     log.warning(
       `PR creation failed after branch "${head}" was pushed ` +
-        `(HTTP ${status ?? 'unknown'}): ${message}. ` +
+        `(HTTP ${status}): ${message}. ` +
         `The branch is ready — a compare URL will be provided.`
     );
     return { prError: { status, message } };

--- a/packages/pi-platform-github/tests/pull-request-create-helpers.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-create-helpers.spec.ts
@@ -15,7 +15,12 @@ import {
   buildCreateSuccessMessage,
   buildCreateSuccessResult,
   formatCreateError,
+  getErrorStatus,
+  buildCompareUrl,
+  buildCreateFallbackMessage,
+  buildCreateFallbackResult,
 } from '@alexanderfortin/pi-platform-github';
+import type { GitHubModuleDeps } from '@alexanderfortin/pi-platform-github';
 
 // ---------------------------------------------------------------------------
 // buildCreateDryRunMessage
@@ -212,5 +217,170 @@ describe('formatCreateError', () => {
     expect(formatCreateError(new CustomError('specific failure'))).toBe(
       '[pull-request] Failed to create pull request: specific failure'
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getErrorStatus
+// ---------------------------------------------------------------------------
+
+describe('getErrorStatus', () => {
+  test('extracts numeric status from Octokit-style error', () => {
+    const error = { status: 404, message: 'Not Found' };
+    expect(getErrorStatus(error)).toBe(404);
+  });
+
+  test('extracts 403 status', () => {
+    const error = { status: 403, message: 'Forbidden' };
+    expect(getErrorStatus(error)).toBe(403);
+  });
+
+  test('extracts 500 status', () => {
+    const error = { status: 500, message: 'Internal Server Error' };
+    expect(getErrorStatus(error)).toBe(500);
+  });
+
+  test('returns undefined when status is not present', () => {
+    expect(getErrorStatus(new Error('plain error'))).toBeUndefined();
+  });
+
+  test('returns undefined when status is a string', () => {
+    expect(getErrorStatus({ status: '404' })).toBeUndefined();
+  });
+
+  test('returns undefined for null', () => {
+    expect(getErrorStatus(null)).toBeUndefined();
+  });
+
+  test('returns undefined for undefined', () => {
+    expect(getErrorStatus(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for primitives', () => {
+    expect(getErrorStatus(42)).toBeUndefined();
+    expect(getErrorStatus('error')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCompareUrl
+// ---------------------------------------------------------------------------
+
+// Minimal deps shape for buildCompareUrl (only context.repo + serverUrl needed)
+function makeCompareDeps(serverUrl: string): GitHubModuleDeps {
+  return {
+    context: {
+      repo: { owner: 'alex', repo: 'ansible' },
+      issue: { number: 18 },
+      eventName: 'issues',
+      payload: {},
+      serverUrl,
+      runId: 1,
+      runNumber: 1,
+      workspace: '/tmp',
+    },
+  } as unknown as GitHubModuleDeps;
+}
+
+describe('buildCompareUrl', () => {
+  test('builds correct URL for Forgejo instance', () => {
+    const deps = makeCompareDeps('https://forge.l3x.in');
+    const url = buildCompareUrl(deps, 'master', 'pi/issue18-1234567890');
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-1234567890');
+  });
+
+  test('builds correct URL for GitHub', () => {
+    const deps = makeCompareDeps('https://github.com');
+    const url = buildCompareUrl(deps, 'main', 'feature/branch');
+    expect(url).toBe('https://github.com/alex/ansible/compare/main...feature/branch');
+  });
+
+  test('strips trailing slash from server URL', () => {
+    const deps = makeCompareDeps('https://forge.l3x.in/');
+    const url = buildCompareUrl(deps, 'master', 'feature');
+    expect(url).toBe('https://forge.l3x.in/alex/ansible/compare/master...feature');
+  });
+
+  test('falls back to github.com when serverUrl is missing', () => {
+    const deps = makeCompareDeps('');
+    const url = buildCompareUrl(deps, 'main', 'feature');
+    expect(url).toBe('https://github.com/alex/ansible/compare/main...feature');
+  });
+
+  test('handles Codeberg URL', () => {
+    const deps = makeCompareDeps('https://codeberg.org');
+    const url = buildCompareUrl(deps, 'main', 'fix/bug');
+    expect(url).toBe('https://codeberg.org/alex/ansible/compare/main...fix/bug');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCreateFallbackMessage
+// ---------------------------------------------------------------------------
+
+describe('buildCreateFallbackMessage', () => {
+  test('includes branch name, error message, and compare URL', () => {
+    const msg = buildCreateFallbackMessage(
+      'master',
+      'pi/issue18-123',
+      'https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-123',
+      'Forbidden'
+    );
+    expect(msg).toContain('pi/issue18-123');
+    expect(msg).toContain('Forbidden');
+    expect(msg).toContain('https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-123');
+  });
+
+  test('states the branch was created and pushed', () => {
+    const msg = buildCreateFallbackMessage('main', 'feature', 'url', 'err');
+    expect(msg).toContain('created and pushed successfully');
+  });
+
+  test('includes a one-click link instruction', () => {
+    const msg = buildCreateFallbackMessage('main', 'feature', 'url', 'err');
+    expect(msg).toContain('open the PR with one click');
+  });
+
+  test('preserves multi-line error messages', () => {
+    const msg = buildCreateFallbackMessage('main', 'feature', 'url', 'line1\nline2');
+    expect(msg).toContain('line1\nline2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCreateFallbackResult
+// ---------------------------------------------------------------------------
+
+describe('buildCreateFallbackResult', () => {
+  test('returns result with prCreated=false and compareUrl set', () => {
+    const result = buildCreateFallbackResult(
+      'message',
+      'pi/issue18-123',
+      'master',
+      'https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-123'
+    );
+    expect(result.details.prCreated).toBe(false);
+    expect(result.details.compareUrl).toBe(
+      'https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-123'
+    );
+    expect(result.details.pullRequestNumber).toBe(0);
+    expect(result.details.pullRequestUrl).toBe('');
+    expect(result.details.dryRun).toBe(false);
+  });
+
+  test('content text matches the message argument', () => {
+    const result = buildCreateFallbackResult('hello world', 'h', 'b', 'url');
+    expect(result.content[0]!.text).toBe('hello world');
+  });
+
+  test('preserves headBranch and baseBranch', () => {
+    const result = buildCreateFallbackResult('msg', 'feature/x', 'main', 'url');
+    expect(result.details.headBranch).toBe('feature/x');
+    expect(result.details.baseBranch).toBe('main');
+  });
+
+  test('content array has exactly one entry', () => {
+    const result = buildCreateFallbackResult('msg', 'h', 'b', 'url');
+    expect(result.content).toHaveLength(1);
   });
 });

--- a/packages/pi-platform-github/tests/pull-request-create-helpers.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-create-helpers.spec.ts
@@ -147,6 +147,7 @@ describe('buildCreateSuccessResult', () => {
         headBranch: 'feature/y',
         baseBranch: 'develop',
         dryRun: false,
+        prCreated: true,
       },
     });
   });
@@ -336,9 +337,9 @@ describe('buildCreateFallbackMessage', () => {
     expect(msg).toContain('created and pushed successfully');
   });
 
-  test('includes a one-click link instruction', () => {
+  test('includes a manual-open link instruction', () => {
     const msg = buildCreateFallbackMessage('main', 'feature', 'url', 'err');
-    expect(msg).toContain('open the PR with one click');
+    expect(msg).toContain('open the PR manually here');
   });
 
   test('preserves multi-line error messages', () => {

--- a/packages/pi-platform-github/tests/pull-request-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-deps.spec.ts
@@ -4,7 +4,10 @@
  * Covers the end-to-end flow of creating a pull request via the GitHub API.
  */
 
-import { describe, expect, test, mock } from 'bun:test';
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   createPullRequest,
   generateBranchName,
@@ -238,5 +241,110 @@ describe('generateBranchName with deps', () => {
     (deps.context as any).issue = undefined;
     const result = generateBranchName(deps, 'Fix bug');
     expect(result).toMatch(/^pi\/issueunknown-\d+$/);
+  });
+});
+
+describe('createPullRequest — fallback when pulls.create fails', () => {
+  // This simulates the Forgejo scenario: the branch/tree/commit operations
+  // succeed (token has push access), but pulls.create fails (token lacks
+  // pull-requests:write). The tool should return a compare-URL fallback
+  // instead of throwing.
+  function createFallbackDeps(workspace: string) {
+    return {
+      octokit: {
+        rest: {
+          pulls: {
+            create: mock(() =>
+              Promise.reject(
+                Object.assign(new Error("Forbidden: Can't read pulls"), { status: 403 })
+              )
+            ),
+          },
+          git: {
+            getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha' } } })),
+            getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
+            getBlob: mock(() => Promise.resolve({ data: { content: '' } })),
+            createRef: mock(() => Promise.resolve({ data: {} })),
+            createBlob: mock(() => Promise.resolve({ data: { sha: 'blob-sha' } })),
+            createTree: mock(() => Promise.resolve({ data: { sha: 'tree-sha' } })),
+            createCommit: mock(() => Promise.resolve({ data: { sha: 'commit-sha' } })),
+            updateRef: mock(() => Promise.resolve({ data: {} })),
+          },
+          repos: {
+            get: mock(() => Promise.resolve({ data: { default_branch: 'main' } })),
+          },
+        },
+      } as any,
+      context: {
+        repo: { owner: 'alex', repo: 'ansible' },
+        issue: { number: 18 },
+        eventName: 'issue_comment',
+        payload: { repository: { default_branch: 'master' } },
+        serverUrl: 'https://forge.l3x.in',
+        runId: 1,
+        runNumber: 1,
+        workspace,
+      },
+      logger: {
+        debug: mock(() => {}),
+        info: mock(() => {}),
+        warning: mock(() => {}),
+        notice: mock(() => {}),
+        error: mock(() => {}),
+      },
+    } as unknown as GitHubModuleDeps;
+  }
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-pr-fallback-'));
+    // Create a file so scanForChanges detects a change
+    fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'hello world');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns fallback result with compare URL when pulls.create fails', async () => {
+    const deps = createFallbackDeps(tempDir);
+    const result = await createPullRequest(deps, { title: 'Fix podman prune' });
+
+    // PR was not created
+    expect(result.details.prCreated).toBe(false);
+    expect(result.details.pullRequestNumber).toBe(0);
+    expect(result.details.pullRequestUrl).toBe('');
+
+    // Compare URL is provided
+    expect(result.details.compareUrl).toContain(
+      'https://forge.l3x.in/alex/ansible/compare/master...'
+    );
+    expect(result.details.compareUrl).toContain('pi/issue18-');
+
+    // The message mentions the branch and includes the compare URL
+    expect(result.content[0]!.text).toContain('created and pushed successfully');
+    expect(result.content[0]!.text).toContain("Can't read pulls");
+    expect(result.content[0]!.text).toContain(result.details.compareUrl!);
+  });
+
+  test('branch ref was created (git data operations succeeded)', async () => {
+    const deps = createFallbackDeps(tempDir);
+    await createPullRequest(deps, { title: 'Fix bug' });
+
+    // Verify git.createRef was called (branch was created)
+    expect(deps.octokit.rest.git.createRef).toHaveBeenCalled();
+    // Verify pulls.create was attempted
+    expect(deps.octokit.rest.pulls.create).toHaveBeenCalled();
+    // Verify createCommit was called (commit was pushed)
+    expect(deps.octokit.rest.git.createCommit).toHaveBeenCalled();
+  });
+
+  test('does not throw — returns a result instead', async () => {
+    const deps = createFallbackDeps(tempDir);
+    // This should NOT throw — the whole point of the fallback
+    const result = await createPullRequest(deps, { title: 'Fix bug' });
+    expect(result).toBeDefined();
+    expect(result.details.prCreated).toBe(false);
   });
 });

--- a/packages/pi-platform-github/tests/pull-request-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-deps.spec.ts
@@ -249,16 +249,18 @@ describe('createPullRequest — fallback when pulls.create fails', () => {
   // succeed (token has push access), but pulls.create fails (token lacks
   // pull-requests:write). The tool should return a compare-URL fallback
   // instead of throwing.
-  function createFallbackDeps(workspace: string) {
+  function createFallbackDeps(workspace: string, pullsCreateImpl?: ReturnType<typeof mock>) {
     return {
       octokit: {
         rest: {
           pulls: {
-            create: mock(() =>
-              Promise.reject(
-                Object.assign(new Error("Forbidden: Can't read pulls"), { status: 403 })
-              )
-            ),
+            create:
+              pullsCreateImpl ??
+              mock(() =>
+                Promise.reject(
+                  Object.assign(new Error("Forbidden: Can't read pulls"), { status: 403 })
+                )
+              ),
           },
           git: {
             getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha' } } })),
@@ -346,5 +348,110 @@ describe('createPullRequest — fallback when pulls.create fails', () => {
     const result = await createPullRequest(deps, { title: 'Fix bug' });
     expect(result).toBeDefined();
     expect(result.details.prCreated).toBe(false);
+  });
+});
+
+describe('createPullRequest — non-permission errors are re-thrown', () => {
+  // Only 401/403 (token-permission) failures trigger the compare-URL
+  // fallback. Other statuses (422 already-exists, 5xx transient) must
+  // propagate so the agent can react appropriately instead of being
+  // silently masked as partial success.
+  function createReThrowDeps(workspace: string, pullsCreateImpl: ReturnType<typeof mock>) {
+    return {
+      octokit: {
+        rest: {
+          pulls: { create: pullsCreateImpl },
+          git: {
+            getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha' } } })),
+            getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
+            getBlob: mock(() => Promise.resolve({ data: { content: '' } })),
+            createRef: mock(() => Promise.resolve({ data: {} })),
+            createBlob: mock(() => Promise.resolve({ data: { sha: 'blob-sha' } })),
+            createTree: mock(() => Promise.resolve({ data: { sha: 'tree-sha' } })),
+            createCommit: mock(() => Promise.resolve({ data: { sha: 'commit-sha' } })),
+            updateRef: mock(() => Promise.resolve({ data: {} })),
+          },
+          repos: {
+            get: mock(() => Promise.resolve({ data: { default_branch: 'main' } })),
+          },
+        },
+      } as any,
+      context: {
+        repo: { owner: 'alex', repo: 'ansible' },
+        issue: { number: 18 },
+        eventName: 'issue_comment',
+        payload: { repository: { default_branch: 'master' } },
+        serverUrl: 'https://forge.l3x.in',
+        runId: 1,
+        runNumber: 1,
+        workspace,
+      },
+      logger: {
+        debug: mock(() => {}),
+        info: mock(() => {}),
+        warning: mock(() => {}),
+        notice: mock(() => {}),
+        error: mock(() => {}),
+      },
+    } as unknown as GitHubModuleDeps;
+  }
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-pr-rethrow-'));
+    fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'hello world');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('422 (PR already exists) is re-thrown, not converted to fallback', async () => {
+    const deps = createReThrowDeps(
+      tempDir,
+      mock(() =>
+        Promise.reject(
+          Object.assign(new Error('Validation Failed: A pull request already exists'), {
+            status: 422,
+          })
+        )
+      )
+    );
+    await expect(createPullRequest(deps, { title: 'Fix bug' })).rejects.toThrow(
+      /Failed to create pull request/
+    );
+  });
+
+  test('500 (server error) is re-thrown, not converted to fallback', async () => {
+    const deps = createReThrowDeps(
+      tempDir,
+      mock(() => Promise.reject(Object.assign(new Error('Internal Server Error'), { status: 500 })))
+    );
+    await expect(createPullRequest(deps, { title: 'Fix bug' })).rejects.toThrow(
+      /Failed to create pull request/
+    );
+  });
+
+  test('error with no status code is re-thrown, not converted to fallback', async () => {
+    const deps = createReThrowDeps(
+      tempDir,
+      mock(() => Promise.reject(new Error('network timeout')))
+    );
+    await expect(createPullRequest(deps, { title: 'Fix bug' })).rejects.toThrow(
+      /Failed to create pull request/
+    );
+  });
+
+  test('401 (unauthorized) still triggers the compare-URL fallback', async () => {
+    const deps = createReThrowDeps(
+      tempDir,
+      mock(() =>
+        Promise.reject(Object.assign(new Error('Requires authentication'), { status: 401 }))
+      )
+    );
+    const result = await createPullRequest(deps, { title: 'Fix bug' });
+    expect(result.details.prCreated).toBe(false);
+    expect(result.details.compareUrl).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #361 — random `create_pull_request` failures on Forgejo runners.

### Root causes identified

The issue reported two distinct failure modes when creating PRs on Forgejo (15.0.3):

1. **API called without `/api/v1` prefix (→ 404):** The action created its Octokit via `github.getOctokit(token)` without specifying a `baseUrl`, relying solely on the `GITHUB_API_URL` env var. On some Forgejo runner configurations, this env var may be missing or misconfigured (lacking the `/api/v1` suffix), causing all REST calls to hit a non-existent endpoint.

2. **Ephemeral token lacks `pull-requests: write` permission:** The Forgejo Actions ephemeral token can have push access (git-data operations: refs, blobs, trees, commits all succeed) but lack PR-creation permissions. The `pulls.create` call fails with *"Can't read pulls or can't read UnitTypeCode"*, even though the branch is fully created and pushed.

3. **No graceful recovery:** When `pulls.create` failed, the tool threw a raw error — even though the branch was already pushed and ready. The agent had to manually construct a compare URL as a workaround, which is unreliable ("random" failures depending on whether the agent chose to use the tool or not).

### Changes

#### 1. Explicit API base URL derivation for Forgejo/Codeberg (`packages/pi-action/src/run.ts`)
- The platform type is now resolved **before** Octokit creation (moved up in the function).
- For `forgejo`/`codeberg` platforms, the API base URL is explicitly derived via `apiBaseUrlFromServerUrl(runnerServerUrl, platformType)` — guaranteeing the `/api/v1` prefix. This matches what the CLI (`pi-cli`) already does.
- The runner-advertised `GITHUB_SERVER_URL` (not the `server_url` *override*) is used, because the API must be reachable from inside the runner.
- For GitHub (including GHES), `getOctokit` continues to use `GITHUB_API_URL` as-is.

#### 2. Graceful PR creation failure with compare-URL fallback (`packages/pi-platform-github/src/tools/pull-request.ts`)
- `prepareBranchAndCreatePR` now separates branch/commit creation from PR opening. If `pulls.create` fails **after** the branch was successfully created and pushed, the error is caught and a structured result is returned instead of throwing.
- New helpers: `buildCompareUrl()`, `buildCreateFallbackMessage()`, `buildCreateFallbackResult()`, `getErrorStatus()`.
- The fallback result includes:
  - `prCreated: false` and `compareUrl` in the structured details
  - A human-readable message with the original error and a one-click compare URL
- Branch/commit creation failures (e.g. no changes, API errors on git-data endpoints) still throw as before.

#### 3. New `CreatePullRequestDetails` fields (`packages/pi-orchestrator/src/platform/types.ts`)
- `prCreated?: boolean` — `false` when the branch was pushed but the PR couldn't be opened
- `compareUrl?: string` — manual-open link when automatic creation failed

#### 4. Updated tool prompt guidelines (`packages/pi-orchestrator/src/pi/prompt.ts`)
- Added a guideline so the agent knows to post the compare URL when the tool returns a fallback result.

### Tests
- **Unit tests** for `getErrorStatus`, `buildCompareUrl`, `buildCreateFallbackMessage`, `buildCreateFallbackResult` (pure helpers)
- **Integration test** simulating the exact Forgejo scenario: git-data operations succeed, `pulls.create` throws (403), and the tool returns a fallback result with the correct compare URL instead of throwing
- All 1105 tests across affected packages pass; 7 pre-existing failures (share/gist tests) are unrelated (caused by `PI_SHARE_VIEWER_URL` env var in CI)

### Example fallback output
When PR creation fails on Forgejo, the tool now returns:
```
Branch "pi/issue18-1716543210000" was created and pushed successfully, but the pull request could not be opened automatically: Forbidden: Can't read pulls

You can open the PR with one click:
https://forge.l3x.in/alex/ansible/compare/master...pi/issue18-1716543210000
```
