### PR TITLE
fix: make system prompt dynamic based on platform input

### DIFF
--- a/packages/pi-orchestrator/src/index.ts
+++ b/packages/pi-orchestrator/src/index.ts
@@ -42,7 +42,7 @@ export type {
   CompactionSectionInput,
 } from './pi/logging';
 export { resolveExtensions, getResourceLoader } from './pi/resource-loader';
-export { getSystemPrompt, SYSTEM_PROMPT, SUPPORTED_PLATFORMS } from './pi/prompt';
+export { getSystemPrompt, getSupportedPlatforms, SYSTEM_PROMPT } from './pi/prompt';
 export { createPRToolFactory } from './pi/tools/create-pr';
 export { createReviewToolFactory } from './pi/tools/create-review';
 export { getCIStatusToolFactory } from './pi/tools/get-ci-status';

--- a/packages/pi-orchestrator/src/index.ts
+++ b/packages/pi-orchestrator/src/index.ts
@@ -42,6 +42,7 @@ export type {
   CompactionSectionInput,
 } from './pi/logging';
 export { resolveExtensions, getResourceLoader } from './pi/resource-loader';
+export { getSystemPrompt, SYSTEM_PROMPT } from './pi/prompt';
 export { createPRToolFactory } from './pi/tools/create-pr';
 export { createReviewToolFactory } from './pi/tools/create-review';
 export { getCIStatusToolFactory } from './pi/tools/get-ci-status';

--- a/packages/pi-orchestrator/src/index.ts
+++ b/packages/pi-orchestrator/src/index.ts
@@ -42,7 +42,7 @@ export type {
   CompactionSectionInput,
 } from './pi/logging';
 export { resolveExtensions, getResourceLoader } from './pi/resource-loader';
-export { getSystemPrompt, SYSTEM_PROMPT } from './pi/prompt';
+export { getSystemPrompt, SYSTEM_PROMPT, SUPPORTED_PLATFORMS } from './pi/prompt';
 export { createPRToolFactory } from './pi/tools/create-pr';
 export { createReviewToolFactory } from './pi/tools/create-review';
 export { getCIStatusToolFactory } from './pi/tools/get-ci-status';

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -6,8 +6,56 @@
  * definitions in {@link ./tools.ts}.
  */
 
-export const SYSTEM_PROMPT =
-  'You are a non-interactive assistant running in GitHub Actions CI/CD environment. You are usually tasked with code reviews and generating code changes. You will not interact with the user directly. The output (or error) you generate will be sent back as comment to the user. Avoid if possible long preambles about what you are going to do to achieve the goal, focus on the final result instead, remember that the user is reading the output as comment in a GitHub PR or issue. IMPORTANT: Do NOT add any footer, signature, metadata, "View action run" text, or similar closing to your response. A footer will be appended automatically - only output your actual response content.';
+import type { PlatformType } from '../platform';
+
+/**
+ * Platform-specific fragments used to build the system prompt.
+ */
+interface PlatformPromptInfo {
+  /** Full CI/CD environment label (e.g. "GitHub Actions CI/CD"). */
+  readonly ciEnvironment: string;
+  /** Short product name for referencing PRs/issues (e.g. "GitHub"). */
+  readonly productName: string;
+}
+
+/**
+ * Per-platform prompt fragments.
+ *
+ * Each supported platform gets its own CI/CD environment label and product
+ * name so the system prompt accurately reflects where the agent is running
+ * instead of always saying "GitHub Actions".
+ */
+const PLATFORM_PROMPT_INFO: Record<PlatformType, PlatformPromptInfo> = {
+  github: { ciEnvironment: 'GitHub Actions CI/CD', productName: 'GitHub' },
+  codeberg: { ciEnvironment: 'Codeberg CI/CD', productName: 'Codeberg' },
+  forgejo: { ciEnvironment: 'Forgejo Actions CI/CD', productName: 'Forgejo' },
+};
+
+/**
+ * Build the system prompt for the given platform.
+ *
+ * The prompt dynamically references the platform the agent is running on
+ * (e.g. "GitHub Actions CI/CD environment" vs "Forgejo Actions CI/CD
+ * environment" and "a GitHub PR or issue" vs "a Forgejo PR or issue") so
+ * that the model is not told it is running on GitHub when it is actually
+ * on Codeberg or Forgejo.
+ *
+ * @param platform - The platform the agent is running on. Defaults to
+ *                   `'github'` for backward compatibility.
+ * @returns The platform-aware system prompt string.
+ */
+export function getSystemPrompt(platform: PlatformType = 'github'): string {
+  const { ciEnvironment, productName } = PLATFORM_PROMPT_INFO[platform];
+  return `You are a non-interactive assistant running in ${ciEnvironment} environment. You are usually tasked with code reviews and generating code changes. You will not interact with the user directly. The output (or error) you generate will be sent back as comment to the user. Avoid if possible long preambles about what you are going to do to achieve the goal, focus on the final result instead, remember that the user is reading the output as comment in a ${productName} PR or issue. IMPORTANT: Do NOT add any footer, signature, metadata, "View action run" text, or similar closing to your response. A footer will be appended automatically - only output your actual response content.`;
+}
+
+/**
+ * The default (GitHub) system prompt.
+ *
+ * Kept for backward compatibility; equivalent to {@link getSystemPrompt}('github').
+ * Prefer {@link getSystemPrompt} when the platform is known.
+ */
+export const SYSTEM_PROMPT = getSystemPrompt('github');
 
 //
 // Create Pull Request

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -57,6 +57,20 @@ export function getSystemPrompt(platform: PlatformType = 'github'): string {
  */
 export const SYSTEM_PROMPT = getSystemPrompt('github');
 
+/**
+ * All supported platforms.
+ *
+ * Derived from {@link PLATFORM_PROMPT_INFO}, which is a
+ * `Record<PlatformType, ...>`, so the list is exhaustive by construction:
+ * adding a new value to {@link PlatformType} forces a matching key in
+ * `PLATFORM_PROMPT_INFO` (and therefore here) at compile time. Consumers
+ * (notably tests) should iterate over this instead of hardcoding a list
+ * so coverage auto-tracks newly added platforms.
+ */
+export const SUPPORTED_PLATFORMS: PlatformType[] = Object.keys(
+  PLATFORM_PROMPT_INFO
+) as PlatformType[];
+
 //
 // Create Pull Request
 //
@@ -72,8 +86,12 @@ export const CREATE_PULL_REQUEST_PROMPT_GUIDELINES = [
   'On some platforms (e.g. Forgejo) the PR object cannot always be opened automatically even though the branch is pushed. When this happens the tool returns a compare URL instead of an error — post that URL so the user can open the PR manually.',
 ];
 
-export const CREATE_PULL_REQUEST_DESCRIPTION =
-  'Create a new pull request on GitHub. This tool handles everything: automatically determines the default base branch, creates a new branch, pushes changes, and creates the PR. The branch name is auto-generated following the pi/issue{number}-{timestamp} pattern.';
+/**
+ * `create_pull_request` tool description, parametrised by platform so the
+ * product name matches where the agent is actually running.
+ */
+export const getCreatePullRequestDescription = (platform: PlatformType = 'github'): string =>
+  `Create a new pull request on ${PLATFORM_PROMPT_INFO[platform].productName}. This tool handles everything: automatically determines the default base branch, creates a new branch, pushes changes, and creates the PR. The branch name is auto-generated following the pi/issue{number}-{timestamp} pattern.`;
 
 export const CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION =
   'Pull request title (should be descriptive and follow conventional commit format)';
@@ -90,18 +108,21 @@ export const CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION =
 //
 // Get Issue/PR Thread
 //
-export const GET_ISSUE_PR_THREAD_PROMPT_SNIPPET =
-  'Get the full comment thread for a GitHub issue or pull request, including title, description, labels, and all comments. For PRs, also includes inline review comments.';
+export const getIssueOrPRThreadPromptSnippet = (platform: PlatformType = 'github'): string =>
+  `Get the full comment thread for a ${PLATFORM_PROMPT_INFO[platform].productName} issue or pull request, including title, description, labels, and all comments. For PRs, also includes inline review comments.`;
 
-export const GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES = [
-  'Use get_issue_or_pr_thread to understand the context of an issue or PR before taking action.',
-  'By default, the tool fetches the current issue/PR from the GitHub context. Only provide owner/repo/issue_number when you need to fetch a different one.',
-  'Use max_comments to limit results for very long threads; defaults to 100 comments.',
-  'For pull requests, the tool also returns inline review comments (comments on specific lines of the diff).',
-];
+export const getIssueOrPRThreadPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
+  const name = PLATFORM_PROMPT_INFO[platform].productName;
+  return [
+    'Use get_issue_or_pr_thread to understand the context of an issue or PR before taking action.',
+    `By default, the tool fetches the current issue/PR from the ${name} context. Only provide owner/repo/issue_number when you need to fetch a different one.`,
+    'Use max_comments to limit results for very long threads; defaults to 100 comments.',
+    'For pull requests, the tool also returns inline review comments (comments on specific lines of the diff).',
+  ];
+};
 
-export const GET_ISSUE_PR_THREAD_DESCRIPTION =
-  'Retrieve the complete comment thread for a GitHub issue or pull request. Returns the title, description, labels, state, author, timestamps, and all comments. For pull requests, also includes inline review comments with file path and line information, plus branch names and merge status. Does NOT fetch code changes — use the get_pr_diff tool for that.';
+export const getIssueOrPRThreadDescription = (platform: PlatformType = 'github'): string =>
+  `Retrieve the complete comment thread for a ${PLATFORM_PROMPT_INFO[platform].productName} issue or pull request. Returns the title, description, labels, state, author, timestamps, and all comments. For pull requests, also includes inline review comments with file path and line information, plus branch names and merge status. Does NOT fetch code changes — use the get_pr_diff tool for that.`;
 
 export const GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION =
   'Repository owner (e.g., "octocat"). If not provided, uses the current repository from context.';
@@ -121,14 +142,19 @@ export const GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION =
 export const UPDATE_PULL_REQUEST_PROMPT_SNIPPET =
   'Update an existing pull request by pushing new commits to the PR branch and optionally updating the title and/or body.';
 
-export const UPDATE_PULL_REQUEST_PROMPT_GUIDELINES = [
-  'Use update_pull_request when working within an existing PR flow to push new commits and/or update PR metadata.',
-  'Make sure your changes are made (modified files exist) before calling this tool. The tool will detect changes and create a new commit on the PR branch.',
-  'By default, the tool works with the current PR from the GitHub context. Only provide pull_number when you need to update a different PR.',
-  'The tool commits changes with the provided message (or generates a default message) and pushes them to the existing PR branch.',
-  'You can update the PR title and/or body using the title and body parameters.',
-  'Use dryRun=true first to verify the update configuration, then dryRun=false to apply the changes.',
-];
+export const getUpdatePullRequestPromptGuidelines = (
+  platform: PlatformType = 'github'
+): string[] => {
+  const name = PLATFORM_PROMPT_INFO[platform].productName;
+  return [
+    'Use update_pull_request when working within an existing PR flow to push new commits and/or update PR metadata.',
+    'Make sure your changes are made (modified files exist) before calling this tool. The tool will detect changes and create a new commit on the PR branch.',
+    `By default, the tool works with the current PR from the ${name} context. Only provide pull_number when you need to update a different PR.`,
+    'The tool commits changes with the provided message (or generates a default message) and pushes them to the existing PR branch.',
+    'You can update the PR title and/or body using the title and body parameters.',
+    'Use dryRun=true first to verify the update configuration, then dryRun=false to apply the changes.',
+  ];
+};
 
 export const UPDATE_PULL_REQUEST_DESCRIPTION =
   'Update an existing pull request by pushing new commits to the PR branch. Optionally updates the PR title and/or description. The tool detects changes in the working tree, creates a new commit on the PR branch, and updates the PR metadata if provided.';
@@ -154,15 +180,18 @@ export const UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION =
 export const GET_PR_DIFF_PROMPT_SNIPPET =
   'Get the diff of a pull request. Use this to understand what code changes a PR introduces.';
 
-export const GET_PR_DIFF_PROMPT_GUIDELINES = [
-  'Use get_pr_diff to fetch the diff of a pull request when you need to understand what changed.',
-  'By default, the tool fetches the diff for the current PR from the GitHub context. Only provide owner/repo/pull_number when you need to fetch a different PR.',
-  'The diff is truncated at 1000 lines and 100KB by default. Use max_lines to increase or decrease the line limit.',
-  'Use ignore_files to exclude common noisy paths (dist/, package-lock.json, etc.) from the diff.',
-];
+export const getPRDiffPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
+  const name = PLATFORM_PROMPT_INFO[platform].productName;
+  return [
+    'Use get_pr_diff to fetch the diff of a pull request when you need to understand what changed.',
+    `By default, the tool fetches the diff for the current PR from the ${name} context. Only provide owner/repo/pull_number when you need to fetch a different PR.`,
+    'The diff is truncated at 1000 lines and 100KB by default. Use max_lines to increase or decrease the line limit.',
+    'Use ignore_files to exclude common noisy paths (dist/, package-lock.json, etc.) from the diff.',
+  ];
+};
 
-export const GET_PR_DIFF_DESCRIPTION =
-  'Fetch the diff of a GitHub pull request. Returns the diff as a string, truncated if too large. Useful for understanding what code changes a PR introduces before reviewing or modifying them.';
+export const getPRDiffDescription = (platform: PlatformType = 'github'): string =>
+  `Fetch the diff of a ${PLATFORM_PROMPT_INFO[platform].productName} pull request. Returns the diff as a string, truncated if too large. Useful for understanding what code changes a PR introduces before reviewing or modifying them.`;
 
 export const GET_PR_DIFF_PARAM_OWNER_DESCRIPTION =
   'Repository owner (e.g., "octocat"). If not provided, uses the current repository from context.';
@@ -196,8 +225,8 @@ export const CREATE_REVIEW_PROMPT_GUIDELINES = [
   'Make sure line numbers reference the correct version of the file. Use the `get_pr_diff` tool first to understand the diff and verify line numbers.',
 ];
 
-export const CREATE_REVIEW_DESCRIPTION =
-  'Create a pull request review with inline comments anchored to specific lines of the diff. Posts a GitHub Pull Request Review using the `pulls.createReview` API with comments positioned on specific lines. Each comment is anchored to a file path and line number in the diff.';
+export const getCreateReviewDescription = (platform: PlatformType = 'github'): string =>
+  `Create a pull request review with inline comments anchored to specific lines of the diff. Posts a ${PLATFORM_PROMPT_INFO[platform].productName} Pull Request Review using the \`pulls.createReview\` API with comments positioned on specific lines. Each comment is anchored to a file path and line number in the diff.`;
 
 export const CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION =
   'Pull request number. If not provided, uses the current PR from context.';
@@ -235,13 +264,16 @@ export const CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION =
 export const GET_CI_STATUS_PROMPT_SNIPPET =
   'Check the CI/CD status for a pull request or commit ref. Returns check runs and workflow runs with their statuses, conclusions, and URLs.';
 
-export const GET_CI_STATUS_PROMPT_GUIDELINES = [
-  'Use get_ci_status to inspect the CI/CD status of a pull request or commit before or after making changes.',
-  'By default, the tool fetches status for the current PR from the GitHub context. Only provide owner/repo/pull_number when you need to check a different PR.',
-  'You can also provide a `ref` (commit SHA or branch name) directly instead of a pull_number.',
-  'Filter by `status` (queued, in_progress, completed) or `conclusion` (success, failure, cancelled, timed_out) to narrow results.',
-  'For failed workflow runs, use the returned run_id with the `get_workflow_run_logs` tool to fetch detailed job logs and diagnose failures.',
-];
+export const getCiStatusPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
+  const name = PLATFORM_PROMPT_INFO[platform].productName;
+  return [
+    'Use get_ci_status to inspect the CI/CD status of a pull request or commit before or after making changes.',
+    `By default, the tool fetches status for the current PR from the ${name} context. Only provide owner/repo/pull_number when you need to check a different PR.`,
+    'You can also provide a `ref` (commit SHA or branch name) directly instead of a pull_number.',
+    'Filter by `status` (queued, in_progress, completed) or `conclusion` (success, failure, cancelled, timed_out) to narrow results.',
+    'For failed workflow runs, use the returned run_id with the `get_workflow_run_logs` tool to fetch detailed job logs and diagnose failures.',
+  ];
+};
 
 export const GET_CI_STATUS_DESCRIPTION =
   'Get the CI/CD status for a pull request or commit ref. Returns a list of check runs and workflow runs with their statuses, conclusions, and URLs. Use this to check if CI is passing or failing before or after making changes.';
@@ -277,8 +309,8 @@ export const GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES = [
   'The tool returns logs for all jobs in the run, with each job clearly labeled. Logs are truncated from the head, preserving the tail where error messages typically appear.',
 ];
 
-export const GET_WORKFLOW_RUN_LOGS_DESCRIPTION =
-  'Fetch the job logs for a specific GitHub Actions workflow run. Returns the log output for each job, truncated if too large. Use this to diagnose CI failures by inspecting the actual error messages and stack traces.';
+export const getWorkflowRunLogsDescription = (platform: PlatformType = 'github'): string =>
+  `Fetch the job logs for a specific ${PLATFORM_PROMPT_INFO[platform].productName} workflow run. Returns the log output for each job, truncated if too large. Use this to diagnose CI failures by inspecting the actual error messages and stack traces.`;
 
 export const GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION =
   'The workflow run ID to fetch logs for. Get this from the get_ci_status tool output.';

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -58,18 +58,25 @@ export function getSystemPrompt(platform: PlatformType = 'github'): string {
 export const SYSTEM_PROMPT = getSystemPrompt('github');
 
 /**
- * All supported platforms.
+ * All platforms with configured prompt fragments.
  *
- * Derived from {@link PLATFORM_PROMPT_INFO}, which is a
- * `Record<PlatformType, ...>`, so the list is exhaustive by construction:
- * adding a new value to {@link PlatformType} forces a matching key in
- * `PLATFORM_PROMPT_INFO` (and therefore here) at compile time. Consumers
- * (notably tests) should iterate over this instead of hardcoding a list
- * so coverage auto-tracks newly added platforms.
+ * Single runtime source of truth for the supported platforms. Tests and
+ * other consumers iterate over this instead of hardcoding the platform
+ * list, so coverage auto-tracks when a new platform is added.
  */
-export const SUPPORTED_PLATFORMS: PlatformType[] = Object.keys(
-  PLATFORM_PROMPT_INFO
-) as PlatformType[];
+export function getSupportedPlatforms(): PlatformType[] {
+  return Object.keys(PLATFORM_PROMPT_INFO) as PlatformType[];
+}
+
+/**
+ * Internal accessor for a platform's short product name (e.g. "GitHub").
+ *
+ * Used to thread the running platform into tool descriptions and
+ * guidelines so the model is not told everything is GitHub.
+ */
+function productNameOf(platform: PlatformType): string {
+  return PLATFORM_PROMPT_INFO[platform].productName;
+}
 
 //
 // Create Pull Request
@@ -87,11 +94,14 @@ export const CREATE_PULL_REQUEST_PROMPT_GUIDELINES = [
 ];
 
 /**
- * `create_pull_request` tool description, parametrised by platform so the
- * product name matches where the agent is actually running.
+ * Build the create_pull_request tool description for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
  */
-export const getCreatePullRequestDescription = (platform: PlatformType = 'github'): string =>
-  `Create a new pull request on ${PLATFORM_PROMPT_INFO[platform].productName}. This tool handles everything: automatically determines the default base branch, creates a new branch, pushes changes, and creates the PR. The branch name is auto-generated following the pi/issue{number}-{timestamp} pattern.`;
+export function CREATE_PULL_REQUEST_DESCRIPTION(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Create a new pull request on ${product}. This tool handles everything: automatically determines the default base branch, creates a new branch, pushes changes, and creates the PR. The branch name is auto-generated following the pi/issue{number}-{timestamp} pattern.`;
+}
 
 export const CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION =
   'Pull request title (should be descriptive and follow conventional commit format)';
@@ -108,21 +118,40 @@ export const CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION =
 //
 // Get Issue/PR Thread
 //
-export const getIssueOrPRThreadPromptSnippet = (platform: PlatformType = 'github'): string =>
-  `Get the full comment thread for a ${PLATFORM_PROMPT_INFO[platform].productName} issue or pull request, including title, description, labels, and all comments. For PRs, also includes inline review comments.`;
+/**
+ * Build the get_issue_or_pr_thread prompt snippet for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_ISSUE_PR_THREAD_PROMPT_SNIPPET(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Get the full comment thread for a ${product} issue or pull request, including title, description, labels, and all comments. For PRs, also includes inline review comments.`;
+}
 
-export const getIssueOrPRThreadPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
-  const name = PLATFORM_PROMPT_INFO[platform].productName;
+/**
+ * Build the get_issue_or_pr_thread prompt guidelines for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES(platform: PlatformType = 'github'): string[] {
+  const product = productNameOf(platform);
   return [
     'Use get_issue_or_pr_thread to understand the context of an issue or PR before taking action.',
-    `By default, the tool fetches the current issue/PR from the ${name} context. Only provide owner/repo/issue_number when you need to fetch a different one.`,
+    `By default, the tool fetches the current issue/PR from the ${product} context. Only provide owner/repo/issue_number when you need to fetch a different one.`,
     'Use max_comments to limit results for very long threads; defaults to 100 comments.',
     'For pull requests, the tool also returns inline review comments (comments on specific lines of the diff).',
   ];
-};
+}
 
-export const getIssueOrPRThreadDescription = (platform: PlatformType = 'github'): string =>
-  `Retrieve the complete comment thread for a ${PLATFORM_PROMPT_INFO[platform].productName} issue or pull request. Returns the title, description, labels, state, author, timestamps, and all comments. For pull requests, also includes inline review comments with file path and line information, plus branch names and merge status. Does NOT fetch code changes — use the get_pr_diff tool for that.`;
+/**
+ * Build the get_issue_or_pr_thread tool description for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_ISSUE_PR_THREAD_DESCRIPTION(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Retrieve the complete comment thread for a ${product} issue or pull request. Returns the title, description, labels, state, author, timestamps, and all comments. For pull requests, also includes inline review comments with file path and line information, plus branch names and merge status. Does NOT fetch code changes — use the get_pr_diff tool for that.`;
+}
 
 export const GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION =
   'Repository owner (e.g., "octocat"). If not provided, uses the current repository from context.';
@@ -142,19 +171,22 @@ export const GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION =
 export const UPDATE_PULL_REQUEST_PROMPT_SNIPPET =
   'Update an existing pull request by pushing new commits to the PR branch and optionally updating the title and/or body.';
 
-export const getUpdatePullRequestPromptGuidelines = (
-  platform: PlatformType = 'github'
-): string[] => {
-  const name = PLATFORM_PROMPT_INFO[platform].productName;
+/**
+ * Build the update_pull_request prompt guidelines for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function UPDATE_PULL_REQUEST_PROMPT_GUIDELINES(platform: PlatformType = 'github'): string[] {
+  const product = productNameOf(platform);
   return [
     'Use update_pull_request when working within an existing PR flow to push new commits and/or update PR metadata.',
     'Make sure your changes are made (modified files exist) before calling this tool. The tool will detect changes and create a new commit on the PR branch.',
-    `By default, the tool works with the current PR from the ${name} context. Only provide pull_number when you need to update a different PR.`,
+    `By default, the tool works with the current PR from the ${product} context. Only provide pull_number when you need to update a different PR.`,
     'The tool commits changes with the provided message (or generates a default message) and pushes them to the existing PR branch.',
     'You can update the PR title and/or body using the title and body parameters.',
     'Use dryRun=true first to verify the update configuration, then dryRun=false to apply the changes.',
   ];
-};
+}
 
 export const UPDATE_PULL_REQUEST_DESCRIPTION =
   'Update an existing pull request by pushing new commits to the PR branch. Optionally updates the PR title and/or description. The tool detects changes in the working tree, creates a new commit on the PR branch, and updates the PR metadata if provided.';
@@ -180,18 +212,30 @@ export const UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION =
 export const GET_PR_DIFF_PROMPT_SNIPPET =
   'Get the diff of a pull request. Use this to understand what code changes a PR introduces.';
 
-export const getPRDiffPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
-  const name = PLATFORM_PROMPT_INFO[platform].productName;
+/**
+ * Build the get_pr_diff prompt guidelines for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_PR_DIFF_PROMPT_GUIDELINES(platform: PlatformType = 'github'): string[] {
+  const product = productNameOf(platform);
   return [
     'Use get_pr_diff to fetch the diff of a pull request when you need to understand what changed.',
-    `By default, the tool fetches the diff for the current PR from the ${name} context. Only provide owner/repo/pull_number when you need to fetch a different PR.`,
+    `By default, the tool fetches the diff for the current PR from the ${product} context. Only provide owner/repo/pull_number when you need to fetch a different PR.`,
     'The diff is truncated at 1000 lines and 100KB by default. Use max_lines to increase or decrease the line limit.',
     'Use ignore_files to exclude common noisy paths (dist/, package-lock.json, etc.) from the diff.',
   ];
-};
+}
 
-export const getPRDiffDescription = (platform: PlatformType = 'github'): string =>
-  `Fetch the diff of a ${PLATFORM_PROMPT_INFO[platform].productName} pull request. Returns the diff as a string, truncated if too large. Useful for understanding what code changes a PR introduces before reviewing or modifying them.`;
+/**
+ * Build the get_pr_diff tool description for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_PR_DIFF_DESCRIPTION(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Fetch the diff of a ${product} pull request. Returns the diff as a string, truncated if too large. Useful for understanding what code changes a PR introduces before reviewing or modifying them.`;
+}
 
 export const GET_PR_DIFF_PARAM_OWNER_DESCRIPTION =
   'Repository owner (e.g., "octocat"). If not provided, uses the current repository from context.';
@@ -225,8 +269,19 @@ export const CREATE_REVIEW_PROMPT_GUIDELINES = [
   'Make sure line numbers reference the correct version of the file. Use the `get_pr_diff` tool first to understand the diff and verify line numbers.',
 ];
 
-export const getCreateReviewDescription = (platform: PlatformType = 'github'): string =>
-  `Create a pull request review with inline comments anchored to specific lines of the diff. Posts a ${PLATFORM_PROMPT_INFO[platform].productName} Pull Request Review using the \`pulls.createReview\` API with comments positioned on specific lines. Each comment is anchored to a file path and line number in the diff.`;
+/**
+ * Build the create_pull_request_review tool description for the given platform.
+ *
+ * The `pulls.createReview` API name is intentionally kept verbatim — all
+ * supported platforms (GitHub, Codeberg, Forgejo) expose a
+ * GitHub-compatible REST API.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function CREATE_REVIEW_DESCRIPTION(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Create a pull request review with inline comments anchored to specific lines of the diff. Posts a ${product} Pull Request Review using the \`pulls.createReview\` API with comments positioned on specific lines. Each comment is anchored to a file path and line number in the diff.`;
+}
 
 export const CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION =
   'Pull request number. If not provided, uses the current PR from context.';
@@ -264,16 +319,21 @@ export const CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION =
 export const GET_CI_STATUS_PROMPT_SNIPPET =
   'Check the CI/CD status for a pull request or commit ref. Returns check runs and workflow runs with their statuses, conclusions, and URLs.';
 
-export const getCiStatusPromptGuidelines = (platform: PlatformType = 'github'): string[] => {
-  const name = PLATFORM_PROMPT_INFO[platform].productName;
+/**
+ * Build the get_ci_status prompt guidelines for the given platform.
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_CI_STATUS_PROMPT_GUIDELINES(platform: PlatformType = 'github'): string[] {
+  const product = productNameOf(platform);
   return [
     'Use get_ci_status to inspect the CI/CD status of a pull request or commit before or after making changes.',
-    `By default, the tool fetches status for the current PR from the ${name} context. Only provide owner/repo/pull_number when you need to check a different PR.`,
+    `By default, the tool fetches status for the current PR from the ${product} context. Only provide owner/repo/pull_number when you need to check a different PR.`,
     'You can also provide a `ref` (commit SHA or branch name) directly instead of a pull_number.',
     'Filter by `status` (queued, in_progress, completed) or `conclusion` (success, failure, cancelled, timed_out) to narrow results.',
     'For failed workflow runs, use the returned run_id with the `get_workflow_run_logs` tool to fetch detailed job logs and diagnose failures.',
   ];
-};
+}
 
 export const GET_CI_STATUS_DESCRIPTION =
   'Get the CI/CD status for a pull request or commit ref. Returns a list of check runs and workflow runs with their statuses, conclusions, and URLs. Use this to check if CI is passing or failing before or after making changes.';
@@ -309,8 +369,19 @@ export const GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES = [
   'The tool returns logs for all jobs in the run, with each job clearly labeled. Logs are truncated from the head, preserving the tail where error messages typically appear.',
 ];
 
-export const getWorkflowRunLogsDescription = (platform: PlatformType = 'github'): string =>
-  `Fetch the job logs for a specific ${PLATFORM_PROMPT_INFO[platform].productName} workflow run. Returns the log output for each job, truncated if too large. Use this to diagnose CI failures by inspecting the actual error messages and stack traces.`;
+/**
+ * Build the get_workflow_run_logs tool description for the given platform.
+ *
+ * Uses "{product} Actions" because all supported platforms run this action
+ * through an Actions-compatible runner (GitHub Actions, Forgejo Actions,
+ * Codeberg's Actions runner).
+ *
+ * @param platform - The platform the agent is running on. Defaults to 'github'.
+ */
+export function GET_WORKFLOW_RUN_LOGS_DESCRIPTION(platform: PlatformType = 'github'): string {
+  const product = productNameOf(platform);
+  return `Fetch the job logs for a specific ${product} Actions workflow run. Returns the log output for each job, truncated if too large. Use this to diagnose CI failures by inspecting the actual error messages and stack traces.`;
+}
 
 export const GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION =
   'The workflow run ID to fetch logs for. Get this from the get_ci_status tool output.';

--- a/packages/pi-orchestrator/src/pi/resource-loader.ts
+++ b/packages/pi-orchestrator/src/pi/resource-loader.ts
@@ -15,7 +15,7 @@ import {
   getAgentDir,
   SettingsManager,
 } from '@earendil-works/pi-coding-agent';
-import { SYSTEM_PROMPT } from './prompt';
+import { getSystemPrompt } from './prompt';
 import { createLoggingFactory } from './logging';
 import type { ExtensionLoadingInfo } from './logging';
 import { createToolsFactory } from './tools/index';
@@ -118,7 +118,7 @@ export async function buildResourceLoaderOptions(
   return {
     extensionFactories,
     additionalExtensionPaths,
-    systemPromptOverride: () => config?.systemPrompt ?? SYSTEM_PROMPT,
+    systemPromptOverride: () => config?.systemPrompt ?? getSystemPrompt(provider.type),
     appendSystemPromptOverride: (agentsFiles: string[]) => {
       if (agentsFiles.length === 0) {
         return [];

--- a/packages/pi-orchestrator/src/pi/tools/create-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-pr.ts
@@ -7,7 +7,7 @@ import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   CREATE_PULL_REQUEST_PROMPT_SNIPPET,
   CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
-  getCreatePullRequestDescription,
+  CREATE_PULL_REQUEST_DESCRIPTION,
   CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
   CREATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
   CREATE_PULL_REQUEST_PARAM_BASE_DESCRIPTION,
@@ -57,7 +57,7 @@ export function createPRToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'create_pull_request',
     label: 'Create Pull Request',
-    description: getCreatePullRequestDescription(provider.type),
+    description: CREATE_PULL_REQUEST_DESCRIPTION(provider.type),
     promptSnippet: CREATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
     parameters: createPullRequestSchema,

--- a/packages/pi-orchestrator/src/pi/tools/create-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-pr.ts
@@ -7,7 +7,7 @@ import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   CREATE_PULL_REQUEST_PROMPT_SNIPPET,
   CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
-  CREATE_PULL_REQUEST_DESCRIPTION,
+  getCreatePullRequestDescription,
   CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
   CREATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
   CREATE_PULL_REQUEST_PARAM_BASE_DESCRIPTION,
@@ -57,7 +57,7 @@ export function createPRToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'create_pull_request',
     label: 'Create Pull Request',
-    description: CREATE_PULL_REQUEST_DESCRIPTION,
+    description: getCreatePullRequestDescription(provider.type),
     promptSnippet: CREATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
     parameters: createPullRequestSchema,

--- a/packages/pi-orchestrator/src/pi/tools/create-review.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-review.ts
@@ -10,7 +10,7 @@ import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   CREATE_REVIEW_PROMPT_SNIPPET,
   CREATE_REVIEW_PROMPT_GUIDELINES,
-  CREATE_REVIEW_DESCRIPTION,
+  getCreateReviewDescription,
   CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION,
   CREATE_REVIEW_PARAM_BODY_DESCRIPTION,
   CREATE_REVIEW_PARAM_EVENT_DESCRIPTION,
@@ -95,7 +95,7 @@ export function createReviewToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'create_pull_request_review',
     label: 'Create Pull Request Review',
-    description: CREATE_REVIEW_DESCRIPTION,
+    description: getCreateReviewDescription(provider.type),
     promptSnippet: CREATE_REVIEW_PROMPT_SNIPPET,
     promptGuidelines: CREATE_REVIEW_PROMPT_GUIDELINES,
     parameters: createReviewSchema,

--- a/packages/pi-orchestrator/src/pi/tools/create-review.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-review.ts
@@ -10,7 +10,7 @@ import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   CREATE_REVIEW_PROMPT_SNIPPET,
   CREATE_REVIEW_PROMPT_GUIDELINES,
-  getCreateReviewDescription,
+  CREATE_REVIEW_DESCRIPTION,
   CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION,
   CREATE_REVIEW_PARAM_BODY_DESCRIPTION,
   CREATE_REVIEW_PARAM_EVENT_DESCRIPTION,
@@ -95,7 +95,7 @@ export function createReviewToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'create_pull_request_review',
     label: 'Create Pull Request Review',
-    description: getCreateReviewDescription(provider.type),
+    description: CREATE_REVIEW_DESCRIPTION(provider.type),
     promptSnippet: CREATE_REVIEW_PROMPT_SNIPPET,
     promptGuidelines: CREATE_REVIEW_PROMPT_GUIDELINES,
     parameters: createReviewSchema,

--- a/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
@@ -9,7 +9,7 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   GET_CI_STATUS_PROMPT_SNIPPET,
-  GET_CI_STATUS_PROMPT_GUIDELINES,
+  getCiStatusPromptGuidelines,
   GET_CI_STATUS_DESCRIPTION,
   GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
   GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
@@ -72,7 +72,7 @@ export function getCIStatusToolFactory(provider: PlatformProvider) {
     label: 'Get CI Status',
     description: GET_CI_STATUS_DESCRIPTION,
     promptSnippet: GET_CI_STATUS_PROMPT_SNIPPET,
-    promptGuidelines: GET_CI_STATUS_PROMPT_GUIDELINES,
+    promptGuidelines: getCiStatusPromptGuidelines(provider.type),
     parameters: getCIStatusSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_CI_STATUS,

--- a/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
@@ -9,7 +9,7 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   GET_CI_STATUS_PROMPT_SNIPPET,
-  getCiStatusPromptGuidelines,
+  GET_CI_STATUS_PROMPT_GUIDELINES,
   GET_CI_STATUS_DESCRIPTION,
   GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
   GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
@@ -72,7 +72,7 @@ export function getCIStatusToolFactory(provider: PlatformProvider) {
     label: 'Get CI Status',
     description: GET_CI_STATUS_DESCRIPTION,
     promptSnippet: GET_CI_STATUS_PROMPT_SNIPPET,
-    promptGuidelines: getCiStatusPromptGuidelines(provider.type),
+    promptGuidelines: GET_CI_STATUS_PROMPT_GUIDELINES(provider.type),
     parameters: getCIStatusSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_CI_STATUS,

--- a/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
@@ -16,8 +16,8 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   GET_PR_DIFF_PROMPT_SNIPPET,
-  getPRDiffPromptGuidelines,
-  getPRDiffDescription,
+  GET_PR_DIFF_PROMPT_GUIDELINES,
+  GET_PR_DIFF_DESCRIPTION,
   GET_PR_DIFF_PARAM_OWNER_DESCRIPTION,
   GET_PR_DIFF_PARAM_REPO_DESCRIPTION,
   GET_PR_DIFF_PARAM_PULL_NUMBER_DESCRIPTION,
@@ -303,9 +303,9 @@ export function getPRDiffToolFactory(provider: PlatformProvider, config?: DiffCo
   return defineTool({
     name: 'get_pr_diff',
     label: 'Get PR Diff',
-    description: getPRDiffDescription(provider.type),
+    description: GET_PR_DIFF_DESCRIPTION(provider.type),
     promptSnippet: GET_PR_DIFF_PROMPT_SNIPPET,
-    promptGuidelines: getPRDiffPromptGuidelines(provider.type),
+    promptGuidelines: GET_PR_DIFF_PROMPT_GUIDELINES(provider.type),
     parameters: getPRDiffSchema,
     execute: withCancellation<GetPRDiffToolParams, GetPRDiffDetails, GetPRDiffToolParams>({
       cancellationMessage: CANCELLATION_MESSAGE_GET_PR_DIFF,

--- a/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
@@ -16,8 +16,8 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   GET_PR_DIFF_PROMPT_SNIPPET,
-  GET_PR_DIFF_PROMPT_GUIDELINES,
-  GET_PR_DIFF_DESCRIPTION,
+  getPRDiffPromptGuidelines,
+  getPRDiffDescription,
   GET_PR_DIFF_PARAM_OWNER_DESCRIPTION,
   GET_PR_DIFF_PARAM_REPO_DESCRIPTION,
   GET_PR_DIFF_PARAM_PULL_NUMBER_DESCRIPTION,
@@ -303,9 +303,9 @@ export function getPRDiffToolFactory(provider: PlatformProvider, config?: DiffCo
   return defineTool({
     name: 'get_pr_diff',
     label: 'Get PR Diff',
-    description: GET_PR_DIFF_DESCRIPTION,
+    description: getPRDiffDescription(provider.type),
     promptSnippet: GET_PR_DIFF_PROMPT_SNIPPET,
-    promptGuidelines: GET_PR_DIFF_PROMPT_GUIDELINES,
+    promptGuidelines: getPRDiffPromptGuidelines(provider.type),
     parameters: getPRDiffSchema,
     execute: withCancellation<GetPRDiffToolParams, GetPRDiffDetails, GetPRDiffToolParams>({
       cancellationMessage: CANCELLATION_MESSAGE_GET_PR_DIFF,

--- a/packages/pi-orchestrator/src/pi/tools/get-thread.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-thread.ts
@@ -5,9 +5,9 @@
 import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
-  getIssueOrPRThreadPromptSnippet,
-  getIssueOrPRThreadPromptGuidelines,
-  getIssueOrPRThreadDescription,
+  GET_ISSUE_PR_THREAD_PROMPT_SNIPPET,
+  GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES,
+  GET_ISSUE_PR_THREAD_DESCRIPTION,
   GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION,
   GET_ISSUE_PR_THREAD_PARAM_REPO_DESCRIPTION,
   GET_ISSUE_PR_THREAD_PARAM_ISSUE_NUMBER_DESCRIPTION,
@@ -85,9 +85,9 @@ export function getIssueOrPRThreadToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'get_issue_or_pr_thread',
     label: 'Get Issue/PR Thread',
-    description: getIssueOrPRThreadDescription(provider.type),
-    promptSnippet: getIssueOrPRThreadPromptSnippet(provider.type),
-    promptGuidelines: getIssueOrPRThreadPromptGuidelines(provider.type),
+    description: GET_ISSUE_PR_THREAD_DESCRIPTION(provider.type),
+    promptSnippet: GET_ISSUE_PR_THREAD_PROMPT_SNIPPET(provider.type),
+    promptGuidelines: GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES(provider.type),
     parameters: getIssueOrPRThreadSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_THREAD,

--- a/packages/pi-orchestrator/src/pi/tools/get-thread.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-thread.ts
@@ -5,9 +5,9 @@
 import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
-  GET_ISSUE_PR_THREAD_PROMPT_SNIPPET,
-  GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES,
-  GET_ISSUE_PR_THREAD_DESCRIPTION,
+  getIssueOrPRThreadPromptSnippet,
+  getIssueOrPRThreadPromptGuidelines,
+  getIssueOrPRThreadDescription,
   GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION,
   GET_ISSUE_PR_THREAD_PARAM_REPO_DESCRIPTION,
   GET_ISSUE_PR_THREAD_PARAM_ISSUE_NUMBER_DESCRIPTION,
@@ -85,9 +85,9 @@ export function getIssueOrPRThreadToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'get_issue_or_pr_thread',
     label: 'Get Issue/PR Thread',
-    description: GET_ISSUE_PR_THREAD_DESCRIPTION,
-    promptSnippet: GET_ISSUE_PR_THREAD_PROMPT_SNIPPET,
-    promptGuidelines: GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES,
+    description: getIssueOrPRThreadDescription(provider.type),
+    promptSnippet: getIssueOrPRThreadPromptSnippet(provider.type),
+    promptGuidelines: getIssueOrPRThreadPromptGuidelines(provider.type),
     parameters: getIssueOrPRThreadSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_THREAD,

--- a/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
@@ -12,7 +12,7 @@ import {
   GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
   GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
   GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
-  getWorkflowRunLogsDescription,
+  GET_WORKFLOW_RUN_LOGS_DESCRIPTION,
   GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION,
   GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
 } from '../prompt';
@@ -60,7 +60,7 @@ export function getWorkflowRunLogsToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'get_workflow_run_logs',
     label: 'Get Workflow Run Logs',
-    description: getWorkflowRunLogsDescription(provider.type),
+    description: GET_WORKFLOW_RUN_LOGS_DESCRIPTION(provider.type),
     promptSnippet: GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
     promptGuidelines: GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
     parameters: getWorkflowRunLogsSchema,

--- a/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
@@ -12,7 +12,7 @@ import {
   GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
   GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
   GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
-  GET_WORKFLOW_RUN_LOGS_DESCRIPTION,
+  getWorkflowRunLogsDescription,
   GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION,
   GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
 } from '../prompt';
@@ -60,7 +60,7 @@ export function getWorkflowRunLogsToolFactory(provider: PlatformProvider) {
   return defineTool({
     name: 'get_workflow_run_logs',
     label: 'Get Workflow Run Logs',
-    description: GET_WORKFLOW_RUN_LOGS_DESCRIPTION,
+    description: getWorkflowRunLogsDescription(provider.type),
     promptSnippet: GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
     promptGuidelines: GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
     parameters: getWorkflowRunLogsSchema,

--- a/packages/pi-orchestrator/src/pi/tools/update-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/update-pr.ts
@@ -6,7 +6,7 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
-  getUpdatePullRequestPromptGuidelines,
+  UPDATE_PULL_REQUEST_PROMPT_GUIDELINES,
   UPDATE_PULL_REQUEST_DESCRIPTION,
   UPDATE_PULL_REQUEST_PARAM_PULL_NUMBER_DESCRIPTION,
   UPDATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
@@ -67,7 +67,7 @@ export function updatePullRequestToolFactory(provider: PlatformProvider) {
     label: 'Update Pull Request',
     description: UPDATE_PULL_REQUEST_DESCRIPTION,
     promptSnippet: UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
-    promptGuidelines: getUpdatePullRequestPromptGuidelines(provider.type),
+    promptGuidelines: UPDATE_PULL_REQUEST_PROMPT_GUIDELINES(provider.type),
     parameters: updatePullRequestSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_UPDATE_PR,

--- a/packages/pi-orchestrator/src/pi/tools/update-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/update-pr.ts
@@ -6,7 +6,7 @@ import { Type, Static } from 'typebox';
 import { defineTool } from '@earendil-works/pi-coding-agent';
 import {
   UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
-  UPDATE_PULL_REQUEST_PROMPT_GUIDELINES,
+  getUpdatePullRequestPromptGuidelines,
   UPDATE_PULL_REQUEST_DESCRIPTION,
   UPDATE_PULL_REQUEST_PARAM_PULL_NUMBER_DESCRIPTION,
   UPDATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
@@ -67,7 +67,7 @@ export function updatePullRequestToolFactory(provider: PlatformProvider) {
     label: 'Update Pull Request',
     description: UPDATE_PULL_REQUEST_DESCRIPTION,
     promptSnippet: UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
-    promptGuidelines: UPDATE_PULL_REQUEST_PROMPT_GUIDELINES,
+    promptGuidelines: getUpdatePullRequestPromptGuidelines(provider.type),
     parameters: updatePullRequestSchema,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_UPDATE_PR,

--- a/packages/pi-orchestrator/tests/pi/prompt.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/prompt.spec.ts
@@ -1,49 +1,55 @@
 /**
  * Tests for platform-aware prompt generation.
  *
- * Verifies that {@link getSystemPrompt} and the per-tool description/guideline
- * builders dynamically reflect the platform the agent is running on (GitHub,
- * Codeberg, Forgejo) instead of always saying "GitHub".
+ * Verifies that the system prompt and all tool descriptions/guidelines
+ * dynamically reflect the platform the agent is running on (GitHub,
+ * Codeberg, Forgejo) instead of always saying "GitHub Actions".
  *
- * The platform list is derived from {@link SUPPORTED_PLATFORMS} (itself
- * derived from the exhaustive `Record<PlatformType, ...>` in `prompt.ts`)
+ * The supported-platform list is derived from {@link getSupportedPlatforms}
+ * (the runtime source of truth in `prompt.ts`) rather than hardcoded here,
  * so these tests automatically cover any platform added in the future.
  */
 
 import { describe, expect, test } from 'bun:test';
-// Public API (also doubles as a smoke test that the barrel re-exports resolve).
 import {
   getSystemPrompt,
+  getSupportedPlatforms,
   SYSTEM_PROMPT,
-  SUPPORTED_PLATFORMS,
 } from '@alexanderfortin/pi-orchestrator';
 import type { PlatformType } from '@alexanderfortin/pi-orchestrator';
-// Internal tool-description builders (kept out of the public barrel).
 import {
-  getCreatePullRequestDescription,
-  getIssueOrPRThreadDescription,
-  getIssueOrPRThreadPromptSnippet,
-  getPRDiffDescription,
-  getCreateReviewDescription,
-  getWorkflowRunLogsDescription,
-  getCiStatusPromptGuidelines,
-  getPRDiffPromptGuidelines,
-  getUpdatePullRequestPromptGuidelines,
-  getIssueOrPRThreadPromptGuidelines,
+  CREATE_PULL_REQUEST_DESCRIPTION,
+  CREATE_REVIEW_DESCRIPTION,
+  GET_CI_STATUS_PROMPT_GUIDELINES,
+  GET_ISSUE_PR_THREAD_DESCRIPTION,
+  GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES,
+  GET_ISSUE_PR_THREAD_PROMPT_SNIPPET,
+  GET_PR_DIFF_DESCRIPTION,
+  GET_PR_DIFF_PROMPT_GUIDELINES,
+  GET_WORKFLOW_RUN_LOGS_DESCRIPTION,
+  UPDATE_PULL_REQUEST_PROMPT_GUIDELINES,
 } from '../../src/pi/prompt';
 
-/** Display names expected per platform (also enforced by `SUPPORTED_PLATFORMS`). */
-const EXPECTED_PRODUCT_NAME: Record<PlatformType, string> = {
+/** Expected short product name per platform (assertions, not data source). */
+const EXPECTED_PRODUCT: Record<PlatformType, string> = {
   github: 'GitHub',
   codeberg: 'Codeberg',
   forgejo: 'Forgejo',
 };
 
-describe('SUPPORTED_PLATFORMS', () => {
-  test('covers the expected set of platforms', () => {
-    expect(SUPPORTED_PLATFORMS).toContain('github');
-    expect(SUPPORTED_PLATFORMS).toContain('codeberg');
-    expect(SUPPORTED_PLATFORMS).toContain('forgejo');
+/** All product names, used to verify no cross-platform leakage. */
+const ALL_PRODUCTS = Object.values(EXPECTED_PRODUCT);
+
+describe('getSupportedPlatforms', () => {
+  test('returns every known platform', () => {
+    const platforms = getSupportedPlatforms();
+    expect(platforms).toContain('github');
+    expect(platforms).toContain('codeberg');
+    expect(platforms).toContain('forgejo');
+  });
+
+  test('returns a non-empty list', () => {
+    expect(getSupportedPlatforms().length).toBeGreaterThan(0);
   });
 });
 
@@ -55,22 +61,39 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('a GitHub PR or issue');
   });
 
-  test('returns the correct prompt for every supported platform', () => {
-    // Iterating over SUPPORTED_PLATFORMS means a newly added platform is
-    // automatically covered here.
-    for (const platform of SUPPORTED_PLATFORMS) {
-      const prompt = getSystemPrompt(platform);
-      const name = EXPECTED_PRODUCT_NAME[platform];
+  test('returns GitHub prompt for "github" platform', () => {
+    const prompt = getSystemPrompt('github');
 
-      expect(prompt).toContain(name);
-    }
+    expect(prompt).toContain('GitHub Actions CI/CD environment');
+    expect(prompt).toContain('a GitHub PR or issue');
+    expect(prompt).not.toContain('Forgejo');
+    expect(prompt).not.toContain('Codeberg');
   });
 
-  test('produces a unique prompt per platform', () => {
-    const prompts = SUPPORTED_PLATFORMS.map(p => getSystemPrompt(p));
+  test('returns Forgejo prompt for "forgejo" platform', () => {
+    const prompt = getSystemPrompt('forgejo');
 
-    // As many distinct prompts as there are platforms.
-    expect(new Set(prompts).size).toBe(SUPPORTED_PLATFORMS.length);
+    expect(prompt).toContain('Forgejo Actions CI/CD environment');
+    expect(prompt).toContain('a Forgejo PR or issue');
+    expect(prompt).not.toContain('GitHub');
+    expect(prompt).not.toContain('Codeberg');
+  });
+
+  test('returns Codeberg prompt for "codeberg" platform', () => {
+    const prompt = getSystemPrompt('codeberg');
+
+    expect(prompt).toContain('Codeberg CI/CD environment');
+    expect(prompt).toContain('a Codeberg PR or issue');
+    expect(prompt).not.toContain('GitHub');
+    expect(prompt).not.toContain('Forgejo');
+  });
+
+  test('produces a different prompt for each platform', () => {
+    const platforms = getSupportedPlatforms();
+    const prompts = platforms.map(p => getSystemPrompt(p));
+
+    // Each platform should yield a unique prompt.
+    expect(new Set(prompts).size).toBe(platforms.length);
   });
 
   test('preserves shared guidance text across all platforms', () => {
@@ -85,22 +108,10 @@ describe('getSystemPrompt', () => {
       'A footer will be appended automatically - only output your actual response content.',
     ];
 
-    for (const platform of SUPPORTED_PLATFORMS) {
+    for (const platform of getSupportedPlatforms()) {
       const prompt = getSystemPrompt(platform);
       for (const fragment of sharedFragments) {
         expect(prompt).toContain(fragment);
-      }
-    }
-  });
-
-  test('never references a different platform than the one requested', () => {
-    for (const platform of SUPPORTED_PLATFORMS) {
-      const prompt = getSystemPrompt(platform);
-      for (const other of SUPPORTED_PLATFORMS) {
-        if (other === platform) {
-          continue;
-        }
-        expect(prompt).not.toContain(EXPECTED_PRODUCT_NAME[other]);
       }
     }
   });
@@ -117,76 +128,124 @@ describe('SYSTEM_PROMPT (backward compatibility)', () => {
   });
 });
 
-/**
- * The tool description / guideline builders must also be platform-aware so
- * the model does not see pervasive "GitHub" references when running on
- * Codeberg or Forgejo (see #365).
- */
 describe('platform-aware tool descriptions & guidelines', () => {
-  /** String builders that interpolate the product name. */
-  const stringBuilders: ((p: PlatformType) => string)[] = [
-    getCreatePullRequestDescription,
-    getIssueOrPRThreadPromptSnippet,
-    getIssueOrPRThreadDescription,
-    getPRDiffDescription,
-    getCreateReviewDescription,
-    getWorkflowRunLogsDescription,
+  // Builders whose output is a single string.
+  const stringBuilders: { label: string; build: (p: PlatformType) => string }[] = [
+    { label: 'CREATE_PULL_REQUEST_DESCRIPTION', build: p => CREATE_PULL_REQUEST_DESCRIPTION(p) },
+    {
+      label: 'GET_ISSUE_PR_THREAD_PROMPT_SNIPPET',
+      build: p => GET_ISSUE_PR_THREAD_PROMPT_SNIPPET(p),
+    },
+    { label: 'GET_ISSUE_PR_THREAD_DESCRIPTION', build: p => GET_ISSUE_PR_THREAD_DESCRIPTION(p) },
+    { label: 'GET_PR_DIFF_DESCRIPTION', build: p => GET_PR_DIFF_DESCRIPTION(p) },
+    { label: 'CREATE_REVIEW_DESCRIPTION', build: p => CREATE_REVIEW_DESCRIPTION(p) },
+    {
+      label: 'GET_WORKFLOW_RUN_LOGS_DESCRIPTION',
+      build: p => GET_WORKFLOW_RUN_LOGS_DESCRIPTION(p),
+    },
   ];
 
-  /** Array builders whose guidelines reference the platform "context". */
-  const arrayBuilders: ((p: PlatformType) => string[])[] = [
-    getIssueOrPRThreadPromptGuidelines,
-    getUpdatePullRequestPromptGuidelines,
-    getPRDiffPromptGuidelines,
-    getCiStatusPromptGuidelines,
+  // Builders whose output is an array of guideline strings (joined for checks).
+  const arrayBuilders: { label: string; build: (p: PlatformType) => string[] }[] = [
+    {
+      label: 'GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES',
+      build: p => GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES(p),
+    },
+    {
+      label: 'UPDATE_PULL_REQUEST_PROMPT_GUIDELINES',
+      build: p => UPDATE_PULL_REQUEST_PROMPT_GUIDELINES(p),
+    },
+    { label: 'GET_PR_DIFF_PROMPT_GUIDELINES', build: p => GET_PR_DIFF_PROMPT_GUIDELINES(p) },
+    { label: 'GET_CI_STATUS_PROMPT_GUIDELINES', build: p => GET_CI_STATUS_PROMPT_GUIDELINES(p) },
   ];
 
-  test('string builders reference the requested product name for every platform', () => {
-    for (const build of stringBuilders) {
-      for (const platform of SUPPORTED_PLATFORMS) {
-        const value = build(platform);
-        expect(value).toContain(EXPECTED_PRODUCT_NAME[platform]);
-      }
-      // Sanity: distinct output per platform.
-      const outputs = SUPPORTED_PLATFORMS.map(build);
-      expect(new Set(outputs).size).toBe(SUPPORTED_PLATFORMS.length);
-    }
-  });
+  for (const platform of getSupportedPlatforms()) {
+    const product = EXPECTED_PRODUCT[platform];
+    const otherProducts = ALL_PRODUCTS.filter(name => name !== product);
 
-  test('string builders never mention a different product than requested', () => {
-    for (const build of stringBuilders) {
-      for (const platform of SUPPORTED_PLATFORMS) {
-        const value = build(platform);
-        for (const other of SUPPORTED_PLATFORMS) {
-          if (other === platform) {
-            continue;
+    describe(`${platform}`, () => {
+      test('string builders reference the active product name', () => {
+        for (const { build } of stringBuilders) {
+          const text = build(platform);
+          expect(text).toContain(product);
+          for (const other of otherProducts) {
+            expect(text).not.toContain(other);
           }
-          expect(value).not.toContain(EXPECTED_PRODUCT_NAME[other]);
         }
-      }
-    }
-  });
+      });
 
-  test('array builders reference the requested product name for every platform', () => {
-    for (const build of arrayBuilders) {
-      for (const platform of SUPPORTED_PLATFORMS) {
-        const value = build(platform);
-        // At least one guideline line should mention the product name.
-        expect(value.join('\n')).toContain(EXPECTED_PRODUCT_NAME[platform]);
-      }
-    }
-  });
-
-  test('array builders never mention a different product than requested', () => {
-    for (const build of arrayBuilders) {
-      for (const platform of SUPPORTED_PLATFORMS) {
-        const joined = build(platform).join('\n');
-        for (const other of SUPPORTED_PLATFORMS) {
-          if (other === platform) {
-            continue;
+      test('array guidelines reference the active product name', () => {
+        for (const { build } of arrayBuilders) {
+          const text = build(platform).join('\n');
+          expect(text).toContain(`${product} context`);
+          for (const other of otherProducts) {
+            expect(text).not.toContain(`${other} context`);
           }
-          expect(joined).not.toContain(EXPECTED_PRODUCT_NAME[other]);
         }
+      });
+    });
+  }
+
+  test('each builder yields a distinct value per platform', () => {
+    const platforms = getSupportedPlatforms();
+    const allBuilders = [
+      ...stringBuilders.map(({ build }) => build),
+      ...arrayBuilders.map(
+        ({ build }) =>
+          (p: PlatformType) =>
+            build(p).join('\n')
+      ),
+    ];
+    for (const build of allBuilders) {
+      const values = platforms.map(p => build(p));
+      expect(new Set(values).size).toBe(platforms.length);
+    }
+  });
+
+  test('string builders default to GitHub when no platform is given', () => {
+    expect(CREATE_PULL_REQUEST_DESCRIPTION()).toContain('GitHub');
+    expect(GET_ISSUE_PR_THREAD_PROMPT_SNIPPET()).toContain('GitHub');
+    expect(GET_ISSUE_PR_THREAD_DESCRIPTION()).toContain('GitHub');
+    expect(GET_PR_DIFF_DESCRIPTION()).toContain('GitHub');
+    expect(CREATE_REVIEW_DESCRIPTION()).toContain('GitHub');
+    expect(GET_WORKFLOW_RUN_LOGS_DESCRIPTION()).toContain('GitHub Actions');
+  });
+
+  test('array guidelines default to GitHub when no platform is given', () => {
+    expect(GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES().join('\n')).toContain('GitHub context');
+    expect(UPDATE_PULL_REQUEST_PROMPT_GUIDELINES().join('\n')).toContain('GitHub context');
+    expect(GET_PR_DIFF_PROMPT_GUIDELINES().join('\n')).toContain('GitHub context');
+    expect(GET_CI_STATUS_PROMPT_GUIDELINES().join('\n')).toContain('GitHub context');
+  });
+
+  test('create review keeps the pulls.createReview API reference for all platforms', () => {
+    for (const platform of getSupportedPlatforms()) {
+      expect(CREATE_REVIEW_DESCRIPTION(platform)).toContain('`pulls.createReview`');
+    }
+  });
+
+  test('workflow run logs keeps the "Actions" runner label for all platforms', () => {
+    for (const platform of getSupportedPlatforms()) {
+      const product = EXPECTED_PRODUCT[platform];
+      expect(GET_WORKFLOW_RUN_LOGS_DESCRIPTION(platform)).toContain(
+        `${product} Actions workflow run`
+      );
+    }
+  });
+
+  test('no builder output leaks the GitHub brand on non-GitHub platforms', () => {
+    const nonGithub = getSupportedPlatforms().filter(p => p !== 'github');
+    const allBuilders: ((p: PlatformType) => string)[] = [
+      ...stringBuilders.map(({ build }) => build),
+      ...arrayBuilders.map(
+        ({ build }) =>
+          (p: PlatformType) =>
+            build(p).join('\n')
+      ),
+    ];
+    for (const platform of nonGithub) {
+      for (const build of allBuilders) {
+        expect(build(platform)).not.toContain('GitHub');
       }
     }
   });

--- a/packages/pi-orchestrator/tests/pi/prompt.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/prompt.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for platform-aware system prompt generation.
+ *
+ * Verifies that {@link getSystemPrompt} dynamically reflects the platform
+ * the agent is running on (GitHub, Codeberg, Forgejo) instead of always
+ * saying "GitHub Actions".
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getSystemPrompt, SYSTEM_PROMPT } from '@alexanderfortin/pi-orchestrator';
+import type { PlatformType } from '@alexanderfortin/pi-orchestrator';
+
+describe('getSystemPrompt', () => {
+  test('defaults to GitHub when no platform is given', () => {
+    const prompt = getSystemPrompt();
+
+    expect(prompt).toContain('GitHub Actions CI/CD environment');
+    expect(prompt).toContain('a GitHub PR or issue');
+  });
+
+  test('returns GitHub prompt for "github" platform', () => {
+    const prompt = getSystemPrompt('github');
+
+    expect(prompt).toContain('GitHub Actions CI/CD environment');
+    expect(prompt).toContain('a GitHub PR or issue');
+    expect(prompt).not.toContain('Forgejo');
+    expect(prompt).not.toContain('Codeberg');
+  });
+
+  test('returns Forgejo prompt for "forgejo" platform', () => {
+    const prompt = getSystemPrompt('forgejo');
+
+    expect(prompt).toContain('Forgejo Actions CI/CD environment');
+    expect(prompt).toContain('a Forgejo PR or issue');
+    expect(prompt).not.toContain('GitHub');
+    expect(prompt).not.toContain('Codeberg');
+  });
+
+  test('returns Codeberg prompt for "codeberg" platform', () => {
+    const prompt = getSystemPrompt('codeberg');
+
+    expect(prompt).toContain('Codeberg CI/CD environment');
+    expect(prompt).toContain('a Codeberg PR or issue');
+    expect(prompt).not.toContain('GitHub');
+    expect(prompt).not.toContain('Forgejo');
+  });
+
+  test('produces a different prompt for each platform', () => {
+    const platforms: PlatformType[] = ['github', 'codeberg', 'forgejo'];
+    const prompts = platforms.map(p => getSystemPrompt(p));
+
+    // All three prompts should be unique
+    expect(new Set(prompts).size).toBe(3);
+  });
+
+  test('preserves shared guidance text across all platforms', () => {
+    const sharedFragments = [
+      'You are a non-interactive assistant running in',
+      'You are usually tasked with code reviews and generating code changes.',
+      'You will not interact with the user directly.',
+      'The output (or error) you generate will be sent back as comment to the user.',
+      'Avoid if possible long preambles about what you are going to do to achieve the goal,',
+      'focus on the final result instead,',
+      'IMPORTANT: Do NOT add any footer, signature, metadata, "View action run" text,',
+      'A footer will be appended automatically - only output your actual response content.',
+    ];
+
+    for (const platform of ['github', 'codeberg', 'forgejo'] as PlatformType[]) {
+      const prompt = getSystemPrompt(platform);
+      for (const fragment of sharedFragments) {
+        expect(prompt).toContain(fragment);
+      }
+    }
+  });
+});
+
+describe('SYSTEM_PROMPT (backward compatibility)', () => {
+  test('equals the GitHub platform prompt', () => {
+    expect(SYSTEM_PROMPT).toBe(getSystemPrompt('github'));
+  });
+
+  test('contains GitHub Actions reference', () => {
+    expect(SYSTEM_PROMPT).toContain('GitHub Actions CI/CD environment');
+    expect(SYSTEM_PROMPT).toContain('a GitHub PR or issue');
+  });
+});

--- a/packages/pi-orchestrator/tests/pi/prompt.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/prompt.spec.ts
@@ -1,14 +1,51 @@
 /**
- * Tests for platform-aware system prompt generation.
+ * Tests for platform-aware prompt generation.
  *
- * Verifies that {@link getSystemPrompt} dynamically reflects the platform
- * the agent is running on (GitHub, Codeberg, Forgejo) instead of always
- * saying "GitHub Actions".
+ * Verifies that {@link getSystemPrompt} and the per-tool description/guideline
+ * builders dynamically reflect the platform the agent is running on (GitHub,
+ * Codeberg, Forgejo) instead of always saying "GitHub".
+ *
+ * The platform list is derived from {@link SUPPORTED_PLATFORMS} (itself
+ * derived from the exhaustive `Record<PlatformType, ...>` in `prompt.ts`)
+ * so these tests automatically cover any platform added in the future.
  */
 
 import { describe, expect, test } from 'bun:test';
-import { getSystemPrompt, SYSTEM_PROMPT } from '@alexanderfortin/pi-orchestrator';
+// Public API (also doubles as a smoke test that the barrel re-exports resolve).
+import {
+  getSystemPrompt,
+  SYSTEM_PROMPT,
+  SUPPORTED_PLATFORMS,
+} from '@alexanderfortin/pi-orchestrator';
 import type { PlatformType } from '@alexanderfortin/pi-orchestrator';
+// Internal tool-description builders (kept out of the public barrel).
+import {
+  getCreatePullRequestDescription,
+  getIssueOrPRThreadDescription,
+  getIssueOrPRThreadPromptSnippet,
+  getPRDiffDescription,
+  getCreateReviewDescription,
+  getWorkflowRunLogsDescription,
+  getCiStatusPromptGuidelines,
+  getPRDiffPromptGuidelines,
+  getUpdatePullRequestPromptGuidelines,
+  getIssueOrPRThreadPromptGuidelines,
+} from '../../src/pi/prompt';
+
+/** Display names expected per platform (also enforced by `SUPPORTED_PLATFORMS`). */
+const EXPECTED_PRODUCT_NAME: Record<PlatformType, string> = {
+  github: 'GitHub',
+  codeberg: 'Codeberg',
+  forgejo: 'Forgejo',
+};
+
+describe('SUPPORTED_PLATFORMS', () => {
+  test('covers the expected set of platforms', () => {
+    expect(SUPPORTED_PLATFORMS).toContain('github');
+    expect(SUPPORTED_PLATFORMS).toContain('codeberg');
+    expect(SUPPORTED_PLATFORMS).toContain('forgejo');
+  });
+});
 
 describe('getSystemPrompt', () => {
   test('defaults to GitHub when no platform is given', () => {
@@ -18,39 +55,22 @@ describe('getSystemPrompt', () => {
     expect(prompt).toContain('a GitHub PR or issue');
   });
 
-  test('returns GitHub prompt for "github" platform', () => {
-    const prompt = getSystemPrompt('github');
+  test('returns the correct prompt for every supported platform', () => {
+    // Iterating over SUPPORTED_PLATFORMS means a newly added platform is
+    // automatically covered here.
+    for (const platform of SUPPORTED_PLATFORMS) {
+      const prompt = getSystemPrompt(platform);
+      const name = EXPECTED_PRODUCT_NAME[platform];
 
-    expect(prompt).toContain('GitHub Actions CI/CD environment');
-    expect(prompt).toContain('a GitHub PR or issue');
-    expect(prompt).not.toContain('Forgejo');
-    expect(prompt).not.toContain('Codeberg');
+      expect(prompt).toContain(name);
+    }
   });
 
-  test('returns Forgejo prompt for "forgejo" platform', () => {
-    const prompt = getSystemPrompt('forgejo');
+  test('produces a unique prompt per platform', () => {
+    const prompts = SUPPORTED_PLATFORMS.map(p => getSystemPrompt(p));
 
-    expect(prompt).toContain('Forgejo Actions CI/CD environment');
-    expect(prompt).toContain('a Forgejo PR or issue');
-    expect(prompt).not.toContain('GitHub');
-    expect(prompt).not.toContain('Codeberg');
-  });
-
-  test('returns Codeberg prompt for "codeberg" platform', () => {
-    const prompt = getSystemPrompt('codeberg');
-
-    expect(prompt).toContain('Codeberg CI/CD environment');
-    expect(prompt).toContain('a Codeberg PR or issue');
-    expect(prompt).not.toContain('GitHub');
-    expect(prompt).not.toContain('Forgejo');
-  });
-
-  test('produces a different prompt for each platform', () => {
-    const platforms: PlatformType[] = ['github', 'codeberg', 'forgejo'];
-    const prompts = platforms.map(p => getSystemPrompt(p));
-
-    // All three prompts should be unique
-    expect(new Set(prompts).size).toBe(3);
+    // As many distinct prompts as there are platforms.
+    expect(new Set(prompts).size).toBe(SUPPORTED_PLATFORMS.length);
   });
 
   test('preserves shared guidance text across all platforms', () => {
@@ -65,10 +85,22 @@ describe('getSystemPrompt', () => {
       'A footer will be appended automatically - only output your actual response content.',
     ];
 
-    for (const platform of ['github', 'codeberg', 'forgejo'] as PlatformType[]) {
+    for (const platform of SUPPORTED_PLATFORMS) {
       const prompt = getSystemPrompt(platform);
       for (const fragment of sharedFragments) {
         expect(prompt).toContain(fragment);
+      }
+    }
+  });
+
+  test('never references a different platform than the one requested', () => {
+    for (const platform of SUPPORTED_PLATFORMS) {
+      const prompt = getSystemPrompt(platform);
+      for (const other of SUPPORTED_PLATFORMS) {
+        if (other === platform) {
+          continue;
+        }
+        expect(prompt).not.toContain(EXPECTED_PRODUCT_NAME[other]);
       }
     }
   });
@@ -82,5 +114,80 @@ describe('SYSTEM_PROMPT (backward compatibility)', () => {
   test('contains GitHub Actions reference', () => {
     expect(SYSTEM_PROMPT).toContain('GitHub Actions CI/CD environment');
     expect(SYSTEM_PROMPT).toContain('a GitHub PR or issue');
+  });
+});
+
+/**
+ * The tool description / guideline builders must also be platform-aware so
+ * the model does not see pervasive "GitHub" references when running on
+ * Codeberg or Forgejo (see #365).
+ */
+describe('platform-aware tool descriptions & guidelines', () => {
+  /** String builders that interpolate the product name. */
+  const stringBuilders: ((p: PlatformType) => string)[] = [
+    getCreatePullRequestDescription,
+    getIssueOrPRThreadPromptSnippet,
+    getIssueOrPRThreadDescription,
+    getPRDiffDescription,
+    getCreateReviewDescription,
+    getWorkflowRunLogsDescription,
+  ];
+
+  /** Array builders whose guidelines reference the platform "context". */
+  const arrayBuilders: ((p: PlatformType) => string[])[] = [
+    getIssueOrPRThreadPromptGuidelines,
+    getUpdatePullRequestPromptGuidelines,
+    getPRDiffPromptGuidelines,
+    getCiStatusPromptGuidelines,
+  ];
+
+  test('string builders reference the requested product name for every platform', () => {
+    for (const build of stringBuilders) {
+      for (const platform of SUPPORTED_PLATFORMS) {
+        const value = build(platform);
+        expect(value).toContain(EXPECTED_PRODUCT_NAME[platform]);
+      }
+      // Sanity: distinct output per platform.
+      const outputs = SUPPORTED_PLATFORMS.map(build);
+      expect(new Set(outputs).size).toBe(SUPPORTED_PLATFORMS.length);
+    }
+  });
+
+  test('string builders never mention a different product than requested', () => {
+    for (const build of stringBuilders) {
+      for (const platform of SUPPORTED_PLATFORMS) {
+        const value = build(platform);
+        for (const other of SUPPORTED_PLATFORMS) {
+          if (other === platform) {
+            continue;
+          }
+          expect(value).not.toContain(EXPECTED_PRODUCT_NAME[other]);
+        }
+      }
+    }
+  });
+
+  test('array builders reference the requested product name for every platform', () => {
+    for (const build of arrayBuilders) {
+      for (const platform of SUPPORTED_PLATFORMS) {
+        const value = build(platform);
+        // At least one guideline line should mention the product name.
+        expect(value.join('\n')).toContain(EXPECTED_PRODUCT_NAME[platform]);
+      }
+    }
+  });
+
+  test('array builders never mention a different product than requested', () => {
+    for (const build of arrayBuilders) {
+      for (const platform of SUPPORTED_PLATFORMS) {
+        const joined = build(platform).join('\n');
+        for (const other of SUPPORTED_PLATFORMS) {
+          if (other === platform) {
+            continue;
+          }
+          expect(joined).not.toContain(EXPECTED_PRODUCT_NAME[other]);
+        }
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

The system prompt was hardcoded with `"running in GitHub Actions CI/CD environment"` for all platforms, including Codeberg and Forgejo. This PR makes the prompt dynamic, honouring the `platform` input.

Fixes #365

## Changes

- **`packages/pi-orchestrator/src/pi/prompt.ts`**: Added `getSystemPrompt(platform)` which builds the prompt using per-platform fragments:
  - `github` → "GitHub Actions CI/CD environment" / "a GitHub PR or issue"
  - `codeberg` → "Codeberg CI/CD environment" / "a Codeberg PR or issue"
  - `forgejo` → "Forgejo Actions CI/CD environment" / "a Forgejo PR or issue"
  
  The `SYSTEM_PROMPT` constant is kept for backward compatibility (= `getSystemPrompt('github')`).

- **`packages/pi-orchestrator/src/pi/resource-loader.ts`**: `systemPromptOverride` now calls `getSystemPrompt(provider.type)` instead of the static `SYSTEM_PROMPT`, so the running platform (resolved from the `platform` input via `parsePlatformType`) drives the prompt. An explicit `config.systemPrompt` override still takes precedence.

- **`packages/pi-orchestrator/src/index.ts`**: Exported `getSystemPrompt` and `SYSTEM_PROMPT` as public API.

- **`packages/pi-orchestrator/tests/pi/prompt.spec.ts`**: New test file verifying platform-aware prompt generation, uniqueness per platform, shared guidance preservation, and backward compatibility.

## Notes

- The 7 failing tests in the orchestrator suite (`share_session` / gist tests) are pre-existing failures on `develop`, unrelated to this change (verified via `git stash`).
- Generated `dist/index.js` was intentionally left unchanged (rebuilt at release time per AGENTS.md).