### PR TITLE
fix(platform-github): treat HTTP 404 from pulls.create as a permission error on Forgejo

### DIFF
--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -568,10 +568,17 @@ async function prepareBranchAndCreatePR(
   // Open the PR — this can fail independently of branch creation (e.g.
   // the token has push access but lacks pull-requests: write on Forgejo).
   //
-  // We only fall back to a compare URL for token-permission failures
-  // (401/403), which is the Forgejo scenario this targets. Other errors
-  // are re-thrown so they surface to the agent/user rather than being
-  // silently masked as partial success:
+  // We only fall back to a compare URL for token-permission failures,
+  // which is the Forgejo scenario this targets:
+  //   - 401/403 — classic permission-denied responses.
+  //   - 404 — Forgejo returns this ("Can't read pulls or can't read
+  //     UnitTypeCode") when the internal actions bot user lacks the
+  //     unit-level permission to create PRs, even though git push
+  //     succeeded. The 404 is semantically a permission error here,
+  //     not a "branch not found" error (the branch was just pushed).
+  //
+  // Other errors are re-thrown so they surface to the agent/user rather
+  // than being silently masked as partial success:
   //   - 422 "A pull request already exists" (e.g. action re-run) → the
   //     agent should use update_pull_request instead of opening a PR
   //     that already exists.
@@ -583,7 +590,7 @@ async function prepareBranchAndCreatePR(
   } catch (error) {
     const status = getErrorStatus(error);
     const message = error instanceof Error ? error.message : String(error);
-    if (status !== 401 && status !== 403) {
+    if (status !== 401 && status !== 403 && status !== 404) {
       log.debug(
         `PR creation failed with HTTP ${status ?? 'unknown'} (not a ` +
           `permission error) — re-throwing after branch "${head}" was pushed.`

--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -494,10 +494,14 @@ interface PrepareBranchAndPRResult {
  * intentionally separated: git-data operations (refs, blobs, trees,
  * commits) can succeed with push-only tokens, while `pulls.create` requires
  * `pull-requests: write`. On Forgejo the ephemeral Actions token sometimes
- * has the former but not the latter, so we catch **only** 401/403
+ * has the former but not the latter, so we catch **only** 401/403/404
  * (permission) errors from `pulls.create` and return a structured result
- * instead of throwing. All other errors (422 already-exists, 5xx, etc.)
- * are re-thrown so they are not silently masked as partial success.
+ * instead of throwing. (Forgejo returns 404 — "Can't read pulls or
+ * can't read UnitTypeCode" — instead of 403 when the internal actions
+ * bot user lacks the unit-level permission to create PRs; see the
+ * inline comment below for details.) All other errors (422
+ * already-exists, 5xx, etc.) are re-thrown so they are not silently
+ * masked as partial success.
  *
  * Throws `Error` when branch/commit creation itself fails (e.g. no changes
  * detected, API error on git-data endpoints) or when PR creation fails with

--- a/packages/pi-platform-github/tests/pull-request-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-deps.spec.ts
@@ -352,7 +352,7 @@ describe('createPullRequest — fallback when pulls.create fails', () => {
 });
 
 describe('createPullRequest — non-permission errors are re-thrown', () => {
-  // Only 401/403 (token-permission) failures trigger the compare-URL
+  // Only 401/403/404 (token-permission) failures trigger the compare-URL
   // fallback. Other statuses (422 already-exists, 5xx transient) must
   // propagate so the agent can react appropriately instead of being
   // silently masked as partial success.
@@ -453,5 +453,26 @@ describe('createPullRequest — non-permission errors are re-thrown', () => {
     const result = await createPullRequest(deps, { title: 'Fix bug' });
     expect(result.details.prCreated).toBe(false);
     expect(result.details.compareUrl).toBeDefined();
+  });
+
+  test('404 (Forgejo "Can\'t read pulls") triggers the compare-URL fallback', async () => {
+    // Forgejo returns 404 instead of 403 when the internal actions bot
+    // user lacks the unit-level permission to create PRs, even though git
+    // push succeeded. This must be treated as a permission error and fall
+    // back to the compare URL rather than being re-thrown.
+    const deps = createReThrowDeps(
+      tempDir,
+      mock(() =>
+        Promise.reject(
+          Object.assign(new Error("Can't read pulls or can't read UnitTypeCode"), {
+            status: 404,
+          })
+        )
+      )
+    );
+    const result = await createPullRequest(deps, { title: 'Fix bug' });
+    expect(result.details.prCreated).toBe(false);
+    expect(result.details.compareUrl).toBeDefined();
+    expect(result.content[0]!.text).toContain("Can't read pulls");
   });
 });

--- a/packages/pi-platform-github/tests/pull-request-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-deps.spec.ts
@@ -453,6 +453,7 @@ describe('createPullRequest — non-permission errors are re-thrown', () => {
     const result = await createPullRequest(deps, { title: 'Fix bug' });
     expect(result.details.prCreated).toBe(false);
     expect(result.details.compareUrl).toBeDefined();
+    expect(result.content[0]!.text).toContain('Requires authentication');
   });
 
   test('404 (Forgejo "Can\'t read pulls") triggers the compare-URL fallback', async () => {


### PR DESCRIPTION
## Summary

Fixes #368

On Forgejo, when the internal `forgejo-actions` bot user (used by `forgejo.token`) has git push access but lacks the unit-level permission to create pull requests, the `pulls.create` API returns **HTTP 404** ("Can't read pulls or can't read UnitTypeCode") rather than 401/403.

The existing graceful fallback — push the branch and provide a compare URL so the user/agent can open the PR manually — only caught 401/403, so the 404 bypassed it entirely and the whole operation failed with no fallback (and no compare URL) even though the branch had already been pushed successfully.

This is why `issue_comment`-triggered runs failed (they need to create a new PR) while `pull_request_comment` runs succeeded (they push to an existing PR branch).

## Changes

**`packages/pi-platform-github/src/tools/pull-request.ts`**
- Added `status !== 404` to the permission-error check in `prepareBranchAndCreatePR`, so a 404 from `pulls.create` is treated as a permission error and triggers the compare-URL fallback instead of being re-thrown.
- Expanded the explanatory comment to document the Forgejo 404 behaviour and why it is semantically a permission error here (the branch was just pushed, so a 404 is not a "branch not found" condition).

**`packages/pi-platform-github/tests/pull-request-deps.spec.ts`**
- Added a test asserting that a 404 (`"Can't read pulls or can't read UnitTypeCode"`) triggers the compare-URL fallback rather than being re-thrown.
- Updated the describe-block comment to reflect `401/403/404`.

Non-permission statuses (422 already-exists, 5xx, missing status code) are still re-thrown as before so the agent can react appropriately.

## Validation

- `bun run validate` (ESLint, type-check, Prettier) — ✅
- `bun test packages/pi-platform-github` — 797 pass, 0 fail
- New `404 (Forgejo "Can't read pulls") triggers the compare-URL fallback` test — ✅

This implements option 2 from the issue analysis, making the action resilient on any Forgejo instance. Note this is complementary to (not a replacement for) option 1 — using a PAT with proper scopes eliminates the problem at the source.