### PR TITLE
fix(release): sync bun.lock workspace versions via targeted script

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,13 +20,13 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun run update-readme && bun run package"
+        "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun install && bun run update-readme && bun run package"
       }
     ],
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "packages/*/package.json", "CHANGELOG.md", "README.md", "dist/index.js"],
+        "assets": ["package.json", "packages/*/package.json", "bun.lock", "CHANGELOG.md", "README.md", "dist/index.js"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,7 +20,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun install && bun run update-readme && bun run package"
+        "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun run sync-lockfile && bun run update-readme && bun run package"
       }
     ],
     [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "semantic-release": "semantic-release",
     "update-readme": "bun run scripts/update-readme-deps.ts",
     "sync-versions": "bun run scripts/sync-versions.ts",
+    "sync-lockfile": "bun run scripts/sync-lockfile.ts",
     "fallow": "bunx fallow",
     "fallow:dead-code": "bunx fallow dead-code",
     "fallow:dupes": "bunx fallow dupes",

--- a/scripts/sync-lockfile.ts
+++ b/scripts/sync-lockfile.ts
@@ -1,0 +1,67 @@
+/**
+ * @file Sync workspace version fields in bun.lock to the released version.
+ *
+ * semantic-release bumps the root `package.json` version
+ * (`@semantic-release/npm`) and `sync-versions` propagates it into every
+ * workspace `package.json`. The last artifact still carrying the stale
+ * version is `bun.lock`, whose `workspaces` section records a `version` for
+ * each workspace package.
+ *
+ * Rather than running a full `bun install` — which hits the network and can
+ * drag unrelated dependency resolutions into the lockfile — this script
+ * surgically updates *only* the workspace `version` fields. A version bump
+ * changes no dependency ranges, so the resolved package set is unaffected:
+ * the sole lockfile delta is the workspace versions.
+ *
+ * Note: `bun install` cannot be used for this purpose. When only `version`
+ * fields change (no dependency-spec changes — exactly the release scenario),
+ * bun considers the lockfile valid ("no changes") and leaves the workspace
+ * versions stale. A dependency-spec change (e.g. in a `chore(deps)` commit) is
+ * what forces a re-resolution that refreshes the lockfile as a side effect.
+ *
+ * Run via: bun run sync-lockfile
+ * Called by the semantic-release prepareCmd, immediately after sync-versions.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const rootPkg = JSON.parse(readFileSync('package.json', 'utf-8'));
+const version = rootPkg.version;
+
+if (!version) {
+  console.error('sync-lockfile: could not determine version from package.json');
+  process.exit(1);
+}
+
+const lockfile = 'bun.lock';
+const content = readFileSync(lockfile, 'utf-8');
+
+/**
+ * Within the `workspaces` object each workspace entry records a `version`
+ * field at 6-space indentation:
+ *
+ *     "packages/pi-action": {
+ *       "name": "@alexanderfortin/pi-action",
+ *       "version": "2.25.0",
+ *
+ * The root workspace ("") has no version, and the trailing `packages` map
+ * embeds versions inside resolved-id strings (e.g. "@actions/core@3.0.1")
+ * rather than as a standalone `"version"` key — so matching a 6-space-indented
+ * `"version"` key is unambiguous.
+ */
+const VERSION_RE = /^      "version": "[^"]+",$/gm;
+
+const matches = content.match(VERSION_RE);
+if (!matches) {
+  console.info('bun.lock: no workspace version fields found — nothing to sync');
+  process.exit(0);
+}
+
+const updated = content.replace(VERSION_RE, `      "version": "${version}",`);
+
+if (updated !== content) {
+  writeFileSync(lockfile, updated);
+  console.info(`bun.lock: synced ${matches.length} workspace version(s) → v${version}`);
+} else {
+  console.info(`bun.lock: workspace versions already at v${version}`);
+}


### PR DESCRIPTION
## Summary

Fixes the stale `bun.lock` issue raised in the review of #372.

Every `chore(release):` commit bumped the version in `package.json` and `packages/*/package.json` (via `@semantic-release/npm` + `sync-versions`) but never updated `bun.lock`, so its workspace `version` fields fell out of sync. The consequence (seen in #372's `bun.lock` diff) is that every subsequent dependency-update PR carries unrelated workspace-version diffs until someone regenerates the lockfile.

## Changes

In `.releaserc.json`:

1. **Added `bun run sync-lockfile` to the `prepareCmd`** — placed immediately after `sync-versions` so the lockfile is updated once all `package.json` version fields are final, and before `package`/`update-readme`.

   ```diff
   - "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun run update-readme && bun run package"
   + "prepareCmd": "bun run scripts/bump-readme-version.ts ${nextRelease.version} && bun run sync-versions && bun run sync-lockfile && bun run update-readme && bun run package"
   ```

2. **Added `bun.lock` to the `@semantic-release/git` assets** so the refreshed lockfile is actually committed in the release commit.

   ```diff
   - "assets": ["package.json", "packages/*/package.json", "CHANGELOG.md", "README.md", "dist/index.js"],
   + "assets": ["package.json", "packages/*/package.json", "bun.lock", "CHANGELOG.md", "README.md", "dist/index.js"],
   ```

3. **New `scripts/sync-lockfile.ts`** (wired via the `sync-lockfile` npm script) — a targeted script that patches only the workspace `version` fields in `bun.lock`'s `workspaces` section.

## Why a targeted script instead of `bun install`?

As noted in the earlier review, `bun install` does **not** work for this case: when only `version` fields change (no dependency-spec changes — exactly the release scenario), bun considers the lockfile valid ("no changes") and leaves the workspace versions stale. It was only ever a dependency-spec change (e.g. the `typebox` bump in #372) that forced a re-resolution and refreshed the lockfile as a side effect.

`bun install` also has unwanted side effects: it hits the network, can drag unrelated dependency resolutions into the lockfile, and triggers the `prepare` lifecycle hook (double-building `dist/index.js`).

The `sync-lockfile` script instead surgically updates the 6-space-indented `"version"` fields in the `workspaces` section — verified to produce a clean 5-line diff with zero transitive-dependency noise. It is also idempotent (skips writing when versions are already in sync).

## Why after `sync-versions`?

`@semantic-release/npm` bumps the root `package.json` version; `sync-versions` propagates that version into every workspace `package.json`. Running `sync-lockfile` only after both steps ensures the lockfile reflects the final version, read directly from the root `package.json`.

Refs #372 (review observation).