### PR TITLE
fix: use repos.getBranch instead of git.getRef for Forgejo compatibility

### DIFF
--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -526,7 +526,7 @@ async function prepareBranchAndCreatePR(
   // (`/git/refs/{ref}`); the singular `/git/ref/{ref}` returns 404, which would break
   // PR creation on those platforms. `repos.getBranch` works on both GitHub and
   // Forgejo/Gitea and returns the commit SHA via `.data.commit.sha`.
-  log.debug(`Getting base branch "${baseBranch}" reference...`);
+  log.debug(`Getting base branch "${baseBranch}" commit SHA...`);
   const baseBranchData = await deps.octokit.rest.repos.getBranch({
     owner,
     repo,

--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -486,7 +486,7 @@ interface PrepareBranchAndPRResult {
  * Prepare the branch and commit on GitHub via the API, then attempt to open
  * a pull request.
  *
- * Wraps the sequence `getRef → buildFileMap → scanForChanges → createRef →
+ * Wraps the sequence `repos.getBranch → buildFileMap → scanForChanges → createRef →
  * createBlobsAndTree → createCommitAndUpdateBranch → createPullRequestOnGitHub`
  * into a single step.
  *
@@ -518,14 +518,21 @@ async function prepareBranchAndCreatePR(
   const owner = deps.context.repo.owner;
   const repo = deps.context.repo.repo;
 
-  // Get base branch reference
+  // Get base branch commit SHA.
+  //
+  // We deliberately use `repos.getBranch` (`GET /repos/{owner}/{repo}/branches/{branch}`)
+  // rather than `git.getRef` (`GET /repos/{owner}/{repo}/git/ref/{ref}`, singular) to
+  // resolve the base branch SHA. Gitea/Forgejo only implements the *plural* form
+  // (`/git/refs/{ref}`); the singular `/git/ref/{ref}` returns 404, which would break
+  // PR creation on those platforms. `repos.getBranch` works on both GitHub and
+  // Forgejo/Gitea and returns the commit SHA via `.data.commit.sha`.
   log.debug(`Getting base branch "${baseBranch}" reference...`);
-  const baseRef = await deps.octokit.rest.git.getRef({
+  const baseBranchData = await deps.octokit.rest.repos.getBranch({
     owner,
     repo,
-    ref: `heads/${baseBranch}`,
+    branch: baseBranch,
   });
-  const baseSha = baseRef.data.object.sha;
+  const baseSha = baseBranchData.data.commit.sha;
   log.debug(`Base branch SHA: ${baseSha}`);
 
   // Get files that exist in the base branch tree (for comparison)

--- a/packages/pi-platform-github/tests/pull-request-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-deps.spec.ts
@@ -23,7 +23,6 @@ function createPRDeps(): GitHubModuleDeps & {
         create: ReturnType<typeof mock>;
       };
       git: {
-        getRef: ReturnType<typeof mock>;
         getTree: ReturnType<typeof mock>;
         getBlob: ReturnType<typeof mock>;
         createRef: ReturnType<typeof mock>;
@@ -34,6 +33,7 @@ function createPRDeps(): GitHubModuleDeps & {
       };
       repos: {
         get: ReturnType<typeof mock>;
+        getBranch: ReturnType<typeof mock>;
       };
     };
   };
@@ -54,7 +54,6 @@ function createPRDeps(): GitHubModuleDeps & {
           ),
         },
         git: {
-          getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha-123' } } })),
           getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
           getBlob: mock(() =>
             Promise.resolve({
@@ -69,6 +68,7 @@ function createPRDeps(): GitHubModuleDeps & {
         },
         repos: {
           get: mock(() => Promise.resolve({ data: { default_branch: 'develop' } })),
+          getBranch: mock(() => Promise.resolve({ data: { commit: { sha: 'base-sha-123' } } })),
         },
       },
     } as any,
@@ -263,7 +263,6 @@ describe('createPullRequest — fallback when pulls.create fails', () => {
               ),
           },
           git: {
-            getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha' } } })),
             getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
             getBlob: mock(() => Promise.resolve({ data: { content: '' } })),
             createRef: mock(() => Promise.resolve({ data: {} })),
@@ -274,6 +273,7 @@ describe('createPullRequest — fallback when pulls.create fails', () => {
           },
           repos: {
             get: mock(() => Promise.resolve({ data: { default_branch: 'main' } })),
+            getBranch: mock(() => Promise.resolve({ data: { commit: { sha: 'base-sha' } } })),
           },
         },
       } as any,
@@ -362,7 +362,6 @@ describe('createPullRequest — non-permission errors are re-thrown', () => {
         rest: {
           pulls: { create: pullsCreateImpl },
           git: {
-            getRef: mock(() => Promise.resolve({ data: { object: { sha: 'base-sha' } } })),
             getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
             getBlob: mock(() => Promise.resolve({ data: { content: '' } })),
             createRef: mock(() => Promise.resolve({ data: {} })),
@@ -373,6 +372,7 @@ describe('createPullRequest — non-permission errors are re-thrown', () => {
           },
           repos: {
             get: mock(() => Promise.resolve({ data: { default_branch: 'main' } })),
+            getBranch: mock(() => Promise.resolve({ data: { commit: { sha: 'base-sha' } } })),
           },
         },
       } as any,

--- a/packages/pi-platform-github/tests/pull-request-update-deps.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-update-deps.spec.ts
@@ -19,7 +19,6 @@ function createUpdateDeps(): GitHubModuleDeps & {
         update: ReturnType<typeof mock>;
       };
       git: {
-        getRef: ReturnType<typeof mock>;
         getTree: ReturnType<typeof mock>;
         getBlob: ReturnType<typeof mock>;
         createBlob: ReturnType<typeof mock>;
@@ -53,7 +52,6 @@ function createUpdateDeps(): GitHubModuleDeps & {
           ),
         },
         git: {
-          getRef: mock(() => Promise.resolve({ data: { object: { sha: 'abc123' } } })),
           getTree: mock(() => Promise.resolve({ data: { tree: [] } })),
           getBlob: mock(() =>
             Promise.resolve({

--- a/packages/pi-platform-github/tests/pull-request-update-logic.spec.ts
+++ b/packages/pi-platform-github/tests/pull-request-update-logic.spec.ts
@@ -73,7 +73,6 @@ describe('applyCommit', () => {
             createCommit,
             updateRef,
             getTree,
-            getRef: mock(() => Promise.resolve({ data: { object: { sha: 'abc' } } })),
             getBlob: mock(() => Promise.resolve({ data: { content: '' } })),
           },
         },


### PR DESCRIPTION
## Summary

Fixes #374

The `create_pull_request` tool resolved the base branch SHA via Octokit's `git.getRef`, which maps to the **singular** REST path `GET /repos/{owner}/{repo}/git/ref/{ref}`. Gitea/Forgejo only implements the **plural** form (`/git/refs/{ref}`), so `git.getRef` returns **404** on those platforms, breaking every PR creation before the branch can even be built.

## Root cause

Per the issue's analysis, this is *not* a token problem — the token has the correct scopes (proven by the same token successfully pushing branches and opening PRs via `/pulls`). Only `git.getRef` is broken; `createRef`, `updateRef`, `getTree`, `getCommit`, and `pulls.create` all work on this Forgejo. Because `getRef` is the **first** step of `prepareBranchAndCreatePR`, the entire create flow 404s before it can make a branch.

Note: `update_pull_request` is unaffected (it resolves the head SHA via `pulls.get`, not `getRef`), which is why updates worked while creates didn't.

## Fix

Replace `git.getRef` with `repos.getBranch` (`GET /repos/{owner}/{repo}/branches/{branch}` → `.data.commit.sha`), which works on **both** GitHub and Forgejo/Gitea:

```js
// before (404 on Forgejo/Gitea):
const baseRef = await octokit.rest.git.getRef({ owner, repo, ref: `heads/${baseBranch}` });
const baseSha = baseRef.data.object.sha;

// after (works everywhere):
const baseBranchData = await octokit.rest.repos.getBranch({ owner, repo, branch: baseBranch });
const baseSha = baseBranchData.data.commit.sha;
```

## Changes

- **`packages/pi-platform-github/src/tools/pull-request.ts`** — `prepareBranchAndCreatePR` now uses `repos.getBranch`; added an explanatory comment documenting why the singular `getRef` must be avoided.
- **`packages/pi-platform-github/tests/pull-request-deps.spec.ts`** — Updated all create-path mocks to provide `repos.getBranch` (returning `data.commit.sha`) instead of `git.getRef` (returning `data.object.sha`).

## Validation

- `bun run validate` (ESLint + tsc + Prettier) ✅
- All 797 tests in `pi-platform-github` pass ✅