### PR TITLE
fix: use platform-aware noreply email for git commit identity

### DIFF
--- a/packages/pi-platform-github/src/git/git-cli.ts
+++ b/packages/pi-platform-github/src/git/git-cli.ts
@@ -14,15 +14,83 @@
 
 import { simpleGit, type SimpleGit } from 'simple-git';
 import ignore from 'ignore';
+import type { PlatformType } from '@alexanderfortin/pi-orchestrator';
 import type { GitHubModuleDeps } from '../types';
 import { GITHUB_IGNORE_PATTERNS } from '../constants';
 
 /**
  * Default git identity used when the CI environment doesn't pre-configure
  * `user.name`/`user.email` (common on Forgejo/Gitea runners).
+ *
+ * The default email is platform-neutral (no `.github.com` suffix) so that
+ * commits created on Forgejo/Codeberg don't reference a non-existent
+ * GitHub address.
  */
 const DEFAULT_GIT_NAME = 'Pi';
-const DEFAULT_GIT_EMAIL = 'pi@users.noreply.github.com';
+const DEFAULT_GIT_EMAIL = 'pi@noreply.pi.local';
+
+/**
+ * Platform context used to choose the correct "noreply" email domain.
+ */
+export interface GitIdentityOptions {
+  /** The detected platform type. */
+  platformType?: PlatformType | undefined;
+  /** The platform server URL (e.g. `https://forgejo.example.com`). */
+  serverUrl?: string | undefined;
+}
+
+/**
+ * Extract the hostname from a server URL.
+ *
+ * Returns a safe fallback when the URL is missing or malformed.
+ */
+function extractHost(serverUrl?: string): string {
+  if (!serverUrl) {
+    return 'noreply.local';
+  }
+  try {
+    return new URL(serverUrl).host;
+  } catch {
+    return 'noreply.local';
+  }
+}
+
+/**
+ * Build a platform-appropriate "noreply" email for the given actor.
+ *
+ * Each forge uses a different noreply scheme:
+ *
+ * - **GitHub**: `<actor>@users.noreply.github.com`
+ * - **Codeberg**: `<actor>@noreply.codeberg.org`
+ * - **Forgejo** (self-hosted): `<actor>@<hostname>` — the hostname is
+ *   derived from the instance's `serverUrl`, mirroring Forgejo's default
+ *   `NO_REPLY_ADDRESS` configuration.
+ *
+ * When no platform context is provided the GitHub scheme is used as a
+ * safe default (the action originated on GitHub and most CI runners
+ * pre-configure git identity anyway).
+ *
+ * @param actor - The CI actor username (e.g. `GITHUB_ACTOR`).
+ * @param opts - Platform context for choosing the correct noreply domain.
+ * @returns The noreply email, or `undefined` when `actor` is falsy.
+ */
+export function getNoreplyEmail(
+  actor: string | undefined,
+  opts?: GitIdentityOptions
+): string | undefined {
+  if (!actor) {
+    return undefined;
+  }
+  switch (opts?.platformType) {
+    case 'forgejo':
+      return `${actor}@${extractHost(opts?.serverUrl)}`;
+    case 'codeberg':
+      return `${actor}@noreply.codeberg.org`;
+    case 'github':
+    default:
+      return `${actor}@users.noreply.github.com`;
+  }
+}
 
 /**
  * Append a `Co-authored-by` trailer to the commit message.
@@ -41,7 +109,11 @@ export function appendCoAuthoredBy(deps: GitHubModuleDeps, message: string): str
   if (!actor) {
     return message;
   }
-  return `${message}\n\nCo-authored-by: ${actor} <${actor}@users.noreply.github.com>`;
+  const email = getNoreplyEmail(actor, {
+    platformType: deps.platformType,
+    serverUrl: deps.context.serverUrl,
+  });
+  return `${message}\n\nCo-authored-by: ${actor} <${email}>`;
 }
 
 /**
@@ -54,10 +126,11 @@ export function appendCoAuthoredBy(deps: GitHubModuleDeps, message: string): str
 export async function ensureGitIdentity(
   git: SimpleGit,
   actor?: string,
-  log?: { debug: (msg: string) => void }
+  log?: { debug: (msg: string) => void },
+  opts?: GitIdentityOptions
 ): Promise<void> {
   const name = actor ?? DEFAULT_GIT_NAME;
-  const email = actor ? `${actor}@users.noreply.github.com` : DEFAULT_GIT_EMAIL;
+  const email = getNoreplyEmail(actor, opts) ?? DEFAULT_GIT_EMAIL;
 
   // Check if identity is already configured (global or local)
   let currentName: string | undefined;
@@ -253,6 +326,12 @@ export interface CommitAndPushOptions {
   /** CI actor, used for git identity when none is configured. */
   actor?: string | undefined;
   /**
+   * Platform context used to derive the correct "noreply" email domain
+   * for the commit author identity. When omitted, defaults to the GitHub
+   * noreply scheme.
+   */
+  gitIdentityOptions?: GitIdentityOptions;
+  /**
    * Specific file paths to stage. Must be non-empty — derived from
    * {@link getWorkspaceChangePaths} (changed + deleted) so that platform
    * ignore patterns are respected and stray files can't leak into the
@@ -283,7 +362,7 @@ export async function commitAndPushBranch(options: CommitAndPushOptions): Promis
   const git = simpleGit(cwd);
 
   // Ensure git identity is configured (Forgejo runners have none)
-  await ensureGitIdentity(git, actor, log);
+  await ensureGitIdentity(git, actor, log, options.gitIdentityOptions);
 
   if (isNewBranch) {
     log.debug(`Creating new branch "${branchName}" from current HEAD…`);

--- a/packages/pi-platform-github/src/git/git-cli.ts
+++ b/packages/pi-platform-github/src/git/git-cli.ts
@@ -49,7 +49,11 @@ function extractHost(serverUrl?: string): string {
     return 'noreply.local';
   }
   try {
-    return new URL(serverUrl).host;
+    // Use `.hostname` (not `.host`) so the port number is excluded —
+    // e.g. `http://forgejo.local:3000` → `forgejo.local`, not
+    // `forgejo.local:3000`. Including the colon would produce an
+    // invalid email domain.
+    return new URL(serverUrl).hostname;
   } catch {
     return 'noreply.local';
   }
@@ -113,6 +117,12 @@ export function appendCoAuthoredBy(deps: GitHubModuleDeps, message: string): str
     platformType: deps.platformType,
     serverUrl: deps.context.serverUrl,
   });
+  // Defensive guard: getNoreplyEmail() returns undefined for a falsy
+  // actor, but a future refactor could break this invariant silently
+  // (producing `<undefined>` in the trailer).
+  if (!email) {
+    return message;
+  }
   return `${message}\n\nCo-authored-by: ${actor} <${email}>`;
 }
 

--- a/packages/pi-platform-github/src/git/index.ts
+++ b/packages/pi-platform-github/src/git/index.ts
@@ -8,10 +8,11 @@
 export { createLogger } from './types';
 
 // Git CLI helpers (branch creation, commit, push — replaces Git Data API writes)
-export type { CommitAndPushOptions, WorkspaceChangePaths } from './git-cli';
+export type { CommitAndPushOptions, WorkspaceChangePaths, GitIdentityOptions } from './git-cli';
 export {
   appendCoAuthoredBy,
   ensureGitIdentity,
+  getNoreplyEmail,
   hasLocalChanges,
   workspaceHasChanges,
   getWorkspaceChangePaths,

--- a/packages/pi-platform-github/src/index.ts
+++ b/packages/pi-platform-github/src/index.ts
@@ -113,6 +113,7 @@ export { getWorkflowRunLogs } from './tools/get-workflow-run-logs';
 export {
   commitAndPushBranch,
   appendCoAuthoredBy,
+  getNoreplyEmail,
   hasLocalChanges,
   workspaceHasChanges,
   ensureGitIdentity,
@@ -121,7 +122,7 @@ export {
   createLogger,
 } from './git';
 
-export type { CommitAndPushOptions, WorkspaceChangePaths } from './git';
+export type { CommitAndPushOptions, WorkspaceChangePaths, GitIdentityOptions } from './git';
 
 // GitHub API token resolution (used by pi-cli + pi-action-bridge)
 export { resolveGitHubToken } from './auth';

--- a/packages/pi-platform-github/src/tools/pull-request-update.ts
+++ b/packages/pi-platform-github/src/tools/pull-request-update.ts
@@ -388,6 +388,10 @@ export async function applyCommit(
     isNewBranch: false,
     paths: [...changedPaths, ...deletedPaths],
     actor: deps.context.actor,
+    gitIdentityOptions: {
+      platformType: deps.platformType,
+      serverUrl: deps.context.serverUrl,
+    },
     log,
   });
   log.info(`Created new commit ${commitSha} on branch ${headBranch}`);

--- a/packages/pi-platform-github/src/tools/pull-request.ts
+++ b/packages/pi-platform-github/src/tools/pull-request.ts
@@ -549,6 +549,10 @@ async function prepareBranchAndCreatePR(
     isNewBranch: true,
     paths: [...changed, ...deleted],
     actor: deps.context.actor,
+    gitIdentityOptions: {
+      platformType: deps.platformType,
+      serverUrl: deps.context.serverUrl,
+    },
     log,
   });
   log.debug(`Branch "${head}" created and pushed successfully`);

--- a/packages/pi-platform-github/tests/git/git-cli.spec.ts
+++ b/packages/pi-platform-github/tests/git/git-cli.spec.ts
@@ -13,6 +13,7 @@ import { execSync } from 'node:child_process';
 import {
   appendCoAuthoredBy,
   ensureGitIdentity,
+  getNoreplyEmail,
   hasLocalChanges,
   workspaceHasChanges,
   getWorkspaceChangePaths,
@@ -60,6 +61,46 @@ function createDeps(actor?: string): { deps: GitHubModuleDeps; messages: string[
 }
 
 // ---------------------------------------------------------------------------
+// getNoreplyEmail
+// ---------------------------------------------------------------------------
+
+describe('getNoreplyEmail', () => {
+  test('returns undefined when actor is falsy', () => {
+    expect(getNoreplyEmail(undefined)).toBeUndefined();
+    expect(getNoreplyEmail('')).toBeUndefined();
+  });
+
+  test('uses GitHub scheme by default', () => {
+    expect(getNoreplyEmail('octocat')).toBe('octocat@users.noreply.github.com');
+  });
+
+  test('uses GitHub scheme explicitly', () => {
+    expect(getNoreplyEmail('octocat', { platformType: 'github' })).toBe(
+      'octocat@users.noreply.github.com'
+    );
+  });
+
+  test('uses Codeberg scheme', () => {
+    expect(getNoreplyEmail('octocat', { platformType: 'codeberg' })).toBe(
+      'octocat@noreply.codeberg.org'
+    );
+  });
+
+  test('uses Forgejo scheme derived from serverUrl', () => {
+    expect(
+      getNoreplyEmail('octocat', {
+        platformType: 'forgejo',
+        serverUrl: 'https://forgejo.example.com',
+      })
+    ).toBe('octocat@forgejo.example.com');
+  });
+
+  test('falls back to noreply.local for Forgejo when serverUrl is missing', () => {
+    expect(getNoreplyEmail('octocat', { platformType: 'forgejo' })).toBe('octocat@noreply.local');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // appendCoAuthoredBy
 // ---------------------------------------------------------------------------
 
@@ -68,6 +109,26 @@ describe('appendCoAuthoredBy', () => {
     const { deps } = createDeps('octocat');
     expect(appendCoAuthoredBy(deps, 'Fix bug')).toBe(
       'Fix bug\n\nCo-authored-by: octocat <octocat@users.noreply.github.com>'
+    );
+  });
+
+  test('appends platform-specific trailer on Forgejo', () => {
+    const { log } = captureLogger();
+    const deps = {
+      context: {
+        repo: { owner: 'test-owner', repo: 'test-repo' },
+        issue: { number: 42 },
+        eventName: 'issue_comment',
+        payload: {},
+        serverUrl: 'https://forgejo.example.com',
+        workspace: '/tmp',
+        actor: 'octocat',
+      },
+      logger: log,
+      platformType: 'forgejo' as const,
+    } as unknown as GitHubModuleDeps;
+    expect(appendCoAuthoredBy(deps, 'Fix bug')).toBe(
+      'Fix bug\n\nCo-authored-by: octocat <octocat@forgejo.example.com>'
     );
   });
 
@@ -111,6 +172,19 @@ describe('ensureGitIdentity', () => {
     expect(messages.some(m => m.includes('user.name'))).toBe(true);
   });
 
+  test('uses platform-specific email on Forgejo', async () => {
+    const { log } = captureLogger();
+    await ensureGitIdentity(git, 'myactor', log, {
+      platformType: 'forgejo',
+      serverUrl: 'https://forgejo.example.com',
+    });
+
+    const name = await git.getConfig('user.name', 'local');
+    const email = await git.getConfig('user.email', 'local');
+    expect(name.value).toBe('myactor');
+    expect(email.value).toBe('myactor@forgejo.example.com');
+  });
+
   test('does not override existing identity', async () => {
     await git.addConfig('user.name', 'existing', false, 'local');
     await git.addConfig('user.email', 'existing@test', false, 'local');
@@ -129,7 +203,7 @@ describe('ensureGitIdentity', () => {
     const name = await git.getConfig('user.name', 'local');
     const email = await git.getConfig('user.email', 'local');
     expect(name.value).toBe('Pi');
-    expect(email.value).toBe('pi@users.noreply.github.com');
+    expect(email.value).toBe('pi@noreply.pi.local');
   });
 
   test('fills in only the missing config field (email absent)', async () => {
@@ -144,7 +218,7 @@ describe('ensureGitIdentity', () => {
     // name should be untouched
     expect(name.value).toBe('partial-name');
     // email should have been set to the default
-    expect(email.value).toBe('pi@users.noreply.github.com');
+    expect(email.value).toBe('pi@noreply.pi.local');
   });
 
   test('logs debug message when configuring email', async () => {

--- a/packages/pi-platform-github/tests/git/git-cli.spec.ts
+++ b/packages/pi-platform-github/tests/git/git-cli.spec.ts
@@ -98,6 +98,23 @@ describe('getNoreplyEmail', () => {
   test('falls back to noreply.local for Forgejo when serverUrl is missing', () => {
     expect(getNoreplyEmail('octocat', { platformType: 'forgejo' })).toBe('octocat@noreply.local');
   });
+
+  test('strips the port for Forgejo when serverUrl includes a non-default port', () => {
+    // Forgejo's default port is 3000; the port must NOT appear in the email
+    // domain (it would produce an invalid address like `user@host:3000`).
+    expect(
+      getNoreplyEmail('octocat', {
+        platformType: 'forgejo',
+        serverUrl: 'http://forgejo.local:3000',
+      })
+    ).toBe('octocat@forgejo.local');
+  });
+
+  test('falls back to noreply.local for Forgejo when serverUrl is malformed', () => {
+    expect(
+      getNoreplyEmail('octocat', { platformType: 'forgejo', serverUrl: 'not-a-valid-url' })
+    ).toBe('octocat@noreply.local');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -135,6 +152,26 @@ describe('appendCoAuthoredBy', () => {
   test('returns message unchanged when actor is empty', () => {
     const { deps } = createDeps('');
     expect(appendCoAuthoredBy(deps, 'Fix bug')).toBe('Fix bug');
+  });
+
+  test('appends Codeberg-specific trailer', () => {
+    const { log } = captureLogger();
+    const deps = {
+      context: {
+        repo: { owner: 'test-owner', repo: 'test-repo' },
+        issue: { number: 42 },
+        eventName: 'issue_comment',
+        payload: {},
+        serverUrl: 'https://codeberg.org',
+        workspace: '/tmp',
+        actor: 'octocat',
+      },
+      logger: log,
+      platformType: 'codeberg' as const,
+    } as unknown as GitHubModuleDeps;
+    expect(appendCoAuthoredBy(deps, 'Fix bug')).toBe(
+      'Fix bug\n\nCo-authored-by: octocat <octocat@noreply.codeberg.org>'
+    );
   });
 
   test('returns message unchanged when actor is undefined', () => {
@@ -183,6 +220,29 @@ describe('ensureGitIdentity', () => {
     const email = await git.getConfig('user.email', 'local');
     expect(name.value).toBe('myactor');
     expect(email.value).toBe('myactor@forgejo.example.com');
+  });
+
+  test('uses Codeberg-specific email', async () => {
+    const { log } = captureLogger();
+    await ensureGitIdentity(git, 'myactor', log, {
+      platformType: 'codeberg',
+    });
+
+    const name = await git.getConfig('user.name', 'local');
+    const email = await git.getConfig('user.email', 'local');
+    expect(name.value).toBe('myactor');
+    expect(email.value).toBe('myactor@noreply.codeberg.org');
+  });
+
+  test('strips the port for Forgejo email when serverUrl has a non-default port', async () => {
+    const { log } = captureLogger();
+    await ensureGitIdentity(git, 'myactor', log, {
+      platformType: 'forgejo',
+      serverUrl: 'http://forgejo.local:3000',
+    });
+
+    const email = await git.getConfig('user.email', 'local');
+    expect(email.value).toBe('myactor@forgejo.local');
   });
 
   test('does not override existing identity', async () => {
@@ -621,6 +681,39 @@ describe('commitAndPushBranch', () => {
     // Identity should have been set locally
     const name = await git.getConfig('user.name', 'local');
     expect(name.value).toBe('ci-bot');
+  });
+
+  test('uses platform-aware noreply email via gitIdentityOptions', async () => {
+    if (!repo) {
+      return;
+    }
+    const { workspace } = repo;
+
+    // Remove any identity config so ensureGitIdentity fills it in
+    const git = simpleGit(workspace);
+    await git.raw(['config', '--unset', 'user.name']);
+    await git.raw(['config', '--unset', 'user.email']);
+
+    fs.writeFileSync(path.join(workspace, 'file.txt'), 'content');
+
+    const { log } = captureLogger();
+    await commitAndPushBranch({
+      cwd: workspace,
+      branchName: 'platform-identity',
+      message: 'Test',
+      isNewBranch: true,
+      paths: ['file.txt'],
+      actor: 'ci-bot',
+      gitIdentityOptions: {
+        platformType: 'forgejo',
+        serverUrl: 'http://forgejo.local:3000',
+      },
+      log,
+    });
+
+    // The port must be stripped (regression test for the .host bug)
+    const email = await git.getConfig('user.email', 'local');
+    expect(email.value).toBe('ci-bot@forgejo.local');
   });
 
   test('pushes to existing branch for updates', async () => {


### PR DESCRIPTION
## Problem

On Forgejo/Codeberg, commits created by the action get authored with `user <user@users.noreply.github.com>` — a GitHub-specific noreply address that doesn't exist on those platforms. This is because `users.noreply.github.com` was hardcoded in three places:

1. `DEFAULT_GIT_EMAIL` — the fallback when no actor is available
2. `ensureGitIdentity()` — the actor-based email for `user.email`
3. `appendCoAuthoredBy()` — the `Co-authored-by` trailer email

Fixes #381.

## Solution

Introduced a new `getNoreplyEmail()` helper that builds the correct noreply email based on the detected platform:

| Platform | Noreply scheme |
|----------|---------------|
| **GitHub** | `<actor>@users.noreply.github.com` |
| **Codeberg** | `<actor>@noreply.codeberg.org` |
| **Forgejo** (self-hosted) | `<actor>@<hostname>` (derived from the instance's `serverUrl`, mirroring Forgejo's default `NO_REPLY_ADDRESS`) |

When no actor is available, the default email is now the platform-neutral `pi@noreply.pi.local` instead of `pi@users.noreply.github.com`.

The platform context (`platformType` + `serverUrl`, both already available on `GitHubModuleDeps`) is threaded through `commitAndPushBranch` → `ensureGitIdentity` via a new `gitIdentityOptions` field on `CommitAndPushOptions`.

## Changes

- **`packages/pi-platform-github/src/git/git-cli.ts`**:
  - New exported `getNoreplyEmail()` function + `GitIdentityOptions` type
  - `DEFAULT_GIT_EMAIL` changed to `pi@noreply.pi.local`
  - `appendCoAuthoredBy()` uses platform-aware email via `getNoreplyEmail()`
  - `ensureGitIdentity()` accepts optional `GitIdentityOptions` (4th param)
  - `CommitAndPushOptions` gains `gitIdentityOptions` field, passed through to `ensureGitIdentity()`
- **`packages/pi-platform-github/src/tools/pull-request.ts`** + **`pull-request-update.ts`**: pass `gitIdentityOptions` from `deps.platformType` / `deps.context.serverUrl`
- **`packages/pi-platform-github/src/git/index.ts`** + **`src/index.ts`**: export `getNoreplyEmail` and `GitIdentityOptions`
- **`packages/pi-platform-github/tests/git/git-cli.spec.ts`**: added tests for `getNoreplyEmail`, platform-specific identity and Co-authored-by behavior; updated existing tests for the new default email

## Validation

- `bun run validate` — ✅ ESLint, TypeScript, Prettier all pass
- `bun test packages/pi-platform-github/` — ✅ 781 pass, 0 fail
