### PR TITLE
feat: opt tools into strict sampling, surface auto-retry events

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "dependencies": {
     "@alexanderfortin/pi-orchestrator": "workspace:*",
     "@alexanderfortin/pi-platform-github": "workspace:*",
-    "@earendil-works/pi-agent-core": "^0.81.1",
-    "@earendil-works/pi-ai": "^0.81.1",
-    "@earendil-works/pi-coding-agent": "^0.81.1"
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1"
   },
   "devDependencies": {
     "@alexanderfortin/semantic-release-keep-a-changelog": "^0.4.9",

--- a/packages/pi-action-bridge/package.json
+++ b/packages/pi-action-bridge/package.json
@@ -13,7 +13,7 @@
     "simple-git": "^3.36.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.81.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1",
     "typebox": "^1.3.6"
   },
   "pi": {

--- a/packages/pi-action-bridge/package.json
+++ b/packages/pi-action-bridge/package.json
@@ -7,6 +7,7 @@
     "pi-package"
   ],
   "dependencies": {
+    "@alexanderfortin/pi-orchestrator": "workspace:*",
     "@alexanderfortin/pi-platform-github": "workspace:*",
     "@octokit/core": "^7.0.6",
     "@octokit/plugin-rest-endpoint-methods": "^17.0.0",

--- a/packages/pi-action-bridge/src/tools/common.ts
+++ b/packages/pi-action-bridge/src/tools/common.ts
@@ -11,6 +11,7 @@
  * Kept framework-agnostic: only `typebox` field schemas + a pure resolver.
  */
 import { Type } from 'typebox';
+import { nullable } from '@alexanderfortin/pi-orchestrator/pi/tools/schema';
 
 /** Canonical web URL used when no `server_url` is supplied (github.com). */
 export const DEFAULT_SERVER_URL = 'https://github.com';
@@ -20,9 +21,10 @@ export const DEFAULT_SERVER_URL = 'https://github.com';
  *
  * Blank / whitespace-only values fall back to {@link DEFAULT_SERVER_URL} so a
  * stray empty string never reaches `apiBaseUrlFromServerUrl` (which throws on
- * empty input).
+ * empty input). Accepts `null` because strict-capable providers emit `null` for
+ * absent optional (nullable) tool fields.
  */
-export function resolveServerUrl(value: string | undefined): string {
+export function resolveServerUrl(value: string | null | undefined): string {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_SERVER_URL;
 }
@@ -37,8 +39,11 @@ export const ownerField = Type.String({ minLength: 1, description: 'Repository o
 /** `repo` field — repository name. */
 export const repoField = Type.String({ minLength: 1, description: 'Repository name.' });
 
-/** `server_url` field — optional forge web URL (defaults to github.com). */
-export const serverUrlField = Type.Optional(
+/** `server_url` field — optional forge web URL (defaults to github.com).
+ *
+ * Modelled as required-but-nullable (`string | null`) for strict JSON-schema
+ * compatibility; a `null` value is treated as "absent" by {@link resolveServerUrl}. */
+export const serverUrlField = nullable(
   Type.String({
     description:
       'Forge web URL (e.g. https://github.com, https://codeberg.org). Defaults to https://github.com.',

--- a/packages/pi-action-bridge/src/tools/detect-pull-request.ts
+++ b/packages/pi-action-bridge/src/tools/detect-pull-request.ts
@@ -14,6 +14,7 @@ import type {
   ExtensionContext,
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
+import { PREFER_STRICT_JSON_SCHEMA } from '@alexanderfortin/pi-orchestrator/pi/tools/schema';
 import { createGitInspector, pickRemote } from '../git';
 import { createOctokitFindPr } from '../octokit';
 import { parseRemoteUrl } from '../remote';
@@ -248,7 +249,8 @@ export const detectPullRequestTool: ToolDefinition<
   promptGuidelines: [
     'Use detect_pull_request before /handoff or /pickup, or whenever you need to know which PR the local branch belongs to. Do not ask the user for a PR number if this tool already resolves one.',
   ],
-  parameters: Type.Object({}),
+  parameters: Type.Object({}, { additionalProperties: false }),
+  constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
   async execute(
     _toolCallId: string,
     _params: Record<string, never>,

--- a/packages/pi-action-bridge/src/tools/post-pr-comment.ts
+++ b/packages/pi-action-bridge/src/tools/post-pr-comment.ts
@@ -20,6 +20,7 @@ import type {
 import { createOctokitPostComment } from '../octokit';
 import type { PostCommentFn, PostPrCommentDetails } from '../types';
 import { ownerField, prNumberField, repoField, resolveServerUrl, serverUrlField } from './common';
+import { PREFER_STRICT_JSON_SCHEMA } from '@alexanderfortin/pi-orchestrator/pi/tools/schema';
 
 /**
  * Post a comment, returning structured details (or an aborted sentinel).
@@ -65,13 +66,16 @@ export function summarizePostComment(details: PostPrCommentDetails): string {
   return `Posted comment ${details.id} on ${details.owner}/${details.repo}#${details.number}: ${details.html_url}`;
 }
 
-const paramsSchema = Type.Object({
-  owner: ownerField,
-  repo: repoField,
-  number: prNumberField('Pull request (or issue) number to comment on.'),
-  body: Type.String({ minLength: 1, description: 'Markdown body of the comment.' }),
-  server_url: serverUrlField,
-});
+const paramsSchema = Type.Object(
+  {
+    owner: ownerField,
+    repo: repoField,
+    number: prNumberField('Pull request (or issue) number to comment on.'),
+    body: Type.String({ minLength: 1, description: 'Markdown body of the comment.' }),
+    server_url: serverUrlField,
+  },
+  { additionalProperties: false }
+);
 
 /**
  * The `post_pr_comment` tool definition.
@@ -91,6 +95,7 @@ export const postPrCommentTool: ToolDefinition<typeof paramsSchema, PostPrCommen
     'Resolve owner/repo/number via detect_pull_request when the user does not pass an explicit PR number.',
   ],
   parameters: paramsSchema,
+  constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
   async execute(
     _toolCallId: string,
     params: {
@@ -98,7 +103,7 @@ export const postPrCommentTool: ToolDefinition<typeof paramsSchema, PostPrCommen
       repo: string;
       number: number;
       body: string;
-      server_url?: string;
+      server_url: string | null;
     },
     signal: AbortSignal | undefined,
     _onUpdate: AgentToolUpdateCallback<PostPrCommentDetails> | undefined,

--- a/packages/pi-action-bridge/src/tools/read-pr-thread.ts
+++ b/packages/pi-action-bridge/src/tools/read-pr-thread.ts
@@ -20,6 +20,10 @@ import type {
 import { createOctokitReadThread, DEFAULT_MAX_THREAD_COMMENTS } from '../octokit';
 import type { NormalizedThread, ReadPrThreadDetails, ReadThreadFn } from '../types';
 import { ownerField, prNumberField, repoField, resolveServerUrl, serverUrlField } from './common';
+import {
+  nullable,
+  PREFER_STRICT_JSON_SCHEMA,
+} from '@alexanderfortin/pi-orchestrator/pi/tools/schema';
 
 /** Per-comment body cap in the text summary (full bodies stay in `details`). */
 const MAX_COMMENT_BODY_CHARS = 2000;
@@ -117,19 +121,22 @@ function truncate(text: string, max: number): string {
   return `${text.slice(0, max)}\n… (truncated; full body in tool details)`;
 }
 
-const paramsSchema = Type.Object({
-  owner: ownerField,
-  repo: repoField,
-  number: prNumberField('Pull request (or issue) number to read.'),
-  max_comments: Type.Optional(
-    Type.Integer({
-      minimum: 1,
-      maximum: 100,
-      description: `Maximum comments to return (default ${DEFAULT_MAX_THREAD_COMMENTS}).`,
-    })
-  ),
-  server_url: serverUrlField,
-});
+const paramsSchema = Type.Object(
+  {
+    owner: ownerField,
+    repo: repoField,
+    number: prNumberField('Pull request (or issue) number to read.'),
+    max_comments: nullable(
+      Type.Integer({
+        minimum: 1,
+        maximum: 100,
+        description: `Maximum comments to return (default ${DEFAULT_MAX_THREAD_COMMENTS}).`,
+      })
+    ),
+    server_url: serverUrlField,
+  },
+  { additionalProperties: false }
+);
 
 /**
  * The `read_pr_thread` tool definition.
@@ -150,14 +157,15 @@ export const readPrThreadTool: ToolDefinition<typeof paramsSchema, ReadPrThreadD
     'The last comment whose body starts with `/pi 🤖 Handoff` is the most recent handoff; summarise its Done/Next sections.',
   ],
   parameters: paramsSchema,
+  constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
   async execute(
     _toolCallId: string,
     params: {
       owner: string;
       repo: string;
       number: number;
-      max_comments?: number;
-      server_url?: string;
+      max_comments: number | null;
+      server_url: string | null;
     },
     signal: AbortSignal | undefined,
     _onUpdate: AgentToolUpdateCallback<ReadPrThreadDetails> | undefined,
@@ -170,7 +178,9 @@ export const readPrThreadTool: ToolDefinition<typeof paramsSchema, ReadPrThreadD
         owner: params.owner,
         repo: params.repo,
         number: params.number,
-        ...(params.max_comments !== undefined ? { maxComments: params.max_comments } : {}),
+        ...(params.max_comments !== null && params.max_comments !== undefined
+          ? { maxComments: params.max_comments }
+          : {}),
       },
       signal
     );

--- a/packages/pi-action-bridge/src/tools/read-pr-thread.ts
+++ b/packages/pi-action-bridge/src/tools/read-pr-thread.ts
@@ -24,6 +24,7 @@ import {
   nullable,
   PREFER_STRICT_JSON_SCHEMA,
 } from '@alexanderfortin/pi-orchestrator/pi/tools/schema';
+import { isPresent } from '@alexanderfortin/pi-orchestrator/pi/tools/tool-execution';
 
 /** Per-comment body cap in the text summary (full bodies stay in `details`). */
 const MAX_COMMENT_BODY_CHARS = 2000;
@@ -178,9 +179,7 @@ export const readPrThreadTool: ToolDefinition<typeof paramsSchema, ReadPrThreadD
         owner: params.owner,
         repo: params.repo,
         number: params.number,
-        ...(params.max_comments !== null && params.max_comments !== undefined
-          ? { maxComments: params.max_comments }
-          : {}),
+        ...(isPresent(params.max_comments) ? { maxComments: params.max_comments } : {}),
       },
       signal
     );

--- a/packages/pi-action/package.json
+++ b/packages/pi-action/package.json
@@ -14,9 +14,9 @@
     "@actions/github": "^9.1.1",
     "@alexanderfortin/pi-orchestrator": "workspace:*",
     "@alexanderfortin/pi-platform-github": "workspace:*",
-    "@earendil-works/pi-agent-core": "^0.81.1",
-    "@earendil-works/pi-ai": "^0.81.1",
-    "@earendil-works/pi-coding-agent": "^0.81.1",
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1",
     "@js-temporal/polyfill": "^0.5.1"
   },
   "devDependencies": {

--- a/packages/pi-cli/package.json
+++ b/packages/pi-cli/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@alexanderfortin/pi-orchestrator": "workspace:*",
     "@alexanderfortin/pi-platform-github": "workspace:*",
-    "@earendil-works/pi-agent-core": "^0.81.1",
-    "@earendil-works/pi-ai": "^0.81.1",
-    "@earendil-works/pi-coding-agent": "^0.81.1",
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1",
     "@js-temporal/polyfill": "^0.5.1",
     "@octokit/core": "^7.0.6",
     "@octokit/plugin-rest-endpoint-methods": "^17.0.0",

--- a/packages/pi-orchestrator/package.json
+++ b/packages/pi-orchestrator/package.json
@@ -10,9 +10,9 @@
     "./pi/tools/*": "./src/pi/tools/*.ts"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.81.1",
-    "@earendil-works/pi-ai": "^0.81.1",
-    "@earendil-works/pi-agent-core": "^0.81.1"
+    "@earendil-works/pi-coding-agent": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-agent-core": "^0.82.1"
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",

--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -269,6 +269,12 @@ export class Agent {
         case 'agent_end':
           this.handleAgentEnd(event.messages);
           break;
+        case 'auto_retry_start':
+          this.handleAutoRetryStart(event);
+          break;
+        case 'auto_retry_end':
+          this.handleAutoRetryEnd(event);
+          break;
         case 'agent_settled':
           // The session has fully settled — no further retries, compactions,
           // or queued continuations will fire. Route the prompt-complete
@@ -413,6 +419,54 @@ export class Agent {
         this.lastAgentError = assistant.stopReason === 'error' ? assistant.errorMessage : undefined;
         break;
       }
+    }
+  }
+
+  /**
+   * Handle `auto_retry_start` session events.
+   *
+   * Pi auto-retries transient provider failures (network/DNS errors, 5xx,
+   * rate limits, early stream endings) per the configured retry policy. Each
+   * retry adds latency and token cost, so surface the start so operators can
+   * correlate slow/expensive runs. This event arrives on the raw session
+   * stream (not the `ExtensionAPI` `pi.on()` surface).
+   *
+   * @param event - The auto-retry-start payload.
+   * @private
+   */
+  private handleAutoRetryStart(event: {
+    attempt: number;
+    maxAttempts: number;
+    delayMs: number;
+    errorMessage: string;
+  }): void {
+    this.logger.info(
+      `[auto-retry] 🔄 provider call retrying — attempt ${event.attempt}/${event.maxAttempts} ` +
+        `after ${event.delayMs}ms (last error: ${event.errorMessage})`
+    );
+  }
+
+  /**
+   * Handle `auto_retry_end` session events.
+   *
+   * Fires when the auto-retry loop settles. Log recovery at info and
+   * exhaustion at warning — a failed retry loop usually precedes a
+   * session-level error that {@link handleAgentEnd} captures, but the
+   * warning makes the exhaustion visible in isolation too.
+   *
+   * @param event - The auto-retry-end payload.
+   * @private
+   */
+  private handleAutoRetryEnd(event: {
+    success: boolean;
+    attempt: number;
+    finalError?: string;
+  }): void {
+    if (event.success) {
+      this.logger.info(`[auto-retry] ✅ recovered on attempt ${event.attempt}`);
+    } else {
+      const detail = event.finalError ? `: ${event.finalError}` : '';
+      this.logger.warning(`[auto-retry] ❌ exhausted after attempt ${event.attempt}${detail}`);
     }
   }
 

--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -23,6 +23,17 @@ import { getPiVersion } from '../version';
 
 import type { AgentSession, AgentSessionEvent } from '@earendil-works/pi-coding-agent';
 import type { Api, AssistantMessageEvent, Model } from '@earendil-works/pi-ai';
+import type { AgentMessage, ThinkingLevel } from '@earendil-works/pi-agent-core';
+import type {
+  PiAgent,
+  PromptResult,
+  SessionStats,
+  Logger,
+  PiConfig,
+  ResourceLoaderConfig,
+  AgentEvents,
+} from '../types';
+import type { PlatformProvider } from '../platform';
 
 /**
  * Derive retry-event payload types from the SDK's `AgentSessionEvent` union so
@@ -39,17 +50,6 @@ type SummarizationRetryAttemptStartEvent = Extract<
   AgentSessionEvent,
   { type: 'summarization_retry_attempt_start' }
 >;
-import type { AgentMessage, ThinkingLevel } from '@earendil-works/pi-agent-core';
-import type {
-  PiAgent,
-  PromptResult,
-  SessionStats,
-  Logger,
-  PiConfig,
-  ResourceLoaderConfig,
-  AgentEvents,
-} from '../types';
-import type { PlatformProvider } from '../platform';
 
 /**
  * Pi coding agent for headless execution inside GitHub Actions.
@@ -278,27 +278,21 @@ export class Agent {
     }
 
     this.sessionEventHandler = (event: AgentSessionEvent) => {
+      // Route all retry-related events (auto_retry_*, summarization_retry_*) to
+      // a dedicated sub-handler. Checked up-front via a string guard rather
+      // than individual `case` labels to keep this dispatcher's cyclomatic
+      // complexity low — the SDK may add further `*_retry_*` variants and they
+      // all belong to the same retry sub-tree.
+      if (event.type.includes('retry')) {
+        this.handleRetryEvent(event);
+        return;
+      }
       switch (event.type) {
         case 'message_update':
           this.handleMessageUpdate(event.assistantMessageEvent);
           break;
         case 'agent_end':
           this.handleAgentEnd(event.messages);
-          break;
-        case 'auto_retry_start':
-          this.handleAutoRetryStart(event);
-          break;
-        case 'auto_retry_end':
-          this.handleAutoRetryEnd(event);
-          break;
-        case 'summarization_retry_scheduled':
-          this.handleSummarizationRetryScheduled(event);
-          break;
-        case 'summarization_retry_attempt_start':
-          this.handleSummarizationRetryAttemptStart(event);
-          break;
-        case 'summarization_retry_finished':
-          this.handleSummarizationRetryFinished();
           break;
         case 'agent_settled':
           // The session has fully settled — no further retries, compactions,
@@ -448,6 +442,38 @@ export class Agent {
   }
 
   /**
+   * Dispatch retry-related session events (`auto_retry_*`, `summarization_retry_*`)
+   * to their dedicated handlers.
+   *
+   * Extracted from the main {@link sessionEventHandler} switch so the primary
+   * dispatcher stays lean and the retry sub-tree is self-contained.
+   *
+   * @param event - A retry-related `AgentSessionEvent`.
+   * @private
+   */
+  private handleRetryEvent(event: AgentSessionEvent): void {
+    switch (event.type) {
+      case 'auto_retry_start':
+        this.handleAutoRetryStart(event);
+        break;
+      case 'auto_retry_end':
+        this.handleAutoRetryEnd(event);
+        break;
+      case 'summarization_retry_scheduled':
+        this.handleSummarizationRetryScheduled(event);
+        break;
+      case 'summarization_retry_attempt_start':
+        this.handleSummarizationRetryAttemptStart(event);
+        break;
+      case 'summarization_retry_finished':
+        this.handleSummarizationRetryFinished();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
    * Handle `auto_retry_start` session events.
    *
    * Pi auto-retries transient provider failures (network/DNS errors, 5xx,
@@ -527,14 +553,15 @@ export class Agent {
    * Handle `summarization_retry_finished` session events.
    *
    * Fires when the summarisation retry loop settles. The SDK does not carry a
-   * success/error field on this event, so we log a plain info line that the
-   * retry loop resolved. Paired with {@link handleSummarizationRetryScheduled}
-   * this brackets the loop so operators can see it began and ended.
+   * success/error field on this event, so we log a neutral marker — not a
+   * green checkmark — to avoid implying recovery. Paired with
+   * {@link handleSummarizationRetryScheduled} this brackets the loop so
+   * operators can see it began and ended.
    *
    * @private
    */
   private handleSummarizationRetryFinished(): void {
-    this.logger.info(`[summarization-retry] ✅ summary retry loop finished`);
+    this.logger.info(`[summarization-retry] • summary retry loop finished`);
   }
 
   /**

--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -23,6 +23,22 @@ import { getPiVersion } from '../version';
 
 import type { AgentSession, AgentSessionEvent } from '@earendil-works/pi-coding-agent';
 import type { Api, AssistantMessageEvent, Model } from '@earendil-works/pi-ai';
+
+/**
+ * Derive retry-event payload types from the SDK's `AgentSessionEvent` union so
+ * the handler signatures stay a single source of truth — if the SDK ever changes
+ * a payload field, the compiler catches the drift here rather than in two places.
+ */
+type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: 'auto_retry_start' }>;
+type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: 'auto_retry_end' }>;
+type SummarizationRetryScheduledEvent = Extract<
+  AgentSessionEvent,
+  { type: 'summarization_retry_scheduled' }
+>;
+type SummarizationRetryAttemptStartEvent = Extract<
+  AgentSessionEvent,
+  { type: 'summarization_retry_attempt_start' }
+>;
 import type { AgentMessage, ThinkingLevel } from '@earendil-works/pi-agent-core';
 import type {
   PiAgent,
@@ -275,6 +291,15 @@ export class Agent {
         case 'auto_retry_end':
           this.handleAutoRetryEnd(event);
           break;
+        case 'summarization_retry_scheduled':
+          this.handleSummarizationRetryScheduled(event);
+          break;
+        case 'summarization_retry_attempt_start':
+          this.handleSummarizationRetryAttemptStart(event);
+          break;
+        case 'summarization_retry_finished':
+          this.handleSummarizationRetryFinished();
+          break;
         case 'agent_settled':
           // The session has fully settled — no further retries, compactions,
           // or queued continuations will fire. Route the prompt-complete
@@ -434,12 +459,7 @@ export class Agent {
    * @param event - The auto-retry-start payload.
    * @private
    */
-  private handleAutoRetryStart(event: {
-    attempt: number;
-    maxAttempts: number;
-    delayMs: number;
-    errorMessage: string;
-  }): void {
+  private handleAutoRetryStart(event: AutoRetryStartEvent): void {
     this.logger.info(
       `[auto-retry] 🔄 provider call retrying — attempt ${event.attempt}/${event.maxAttempts} ` +
         `after ${event.delayMs}ms (last error: ${event.errorMessage})`
@@ -457,17 +477,64 @@ export class Agent {
    * @param event - The auto-retry-end payload.
    * @private
    */
-  private handleAutoRetryEnd(event: {
-    success: boolean;
-    attempt: number;
-    finalError?: string;
-  }): void {
+  private handleAutoRetryEnd(event: AutoRetryEndEvent): void {
     if (event.success) {
       this.logger.info(`[auto-retry] ✅ recovered on attempt ${event.attempt}`);
     } else {
       const detail = event.finalError ? `: ${event.finalError}` : '';
       this.logger.warning(`[auto-retry] ❌ exhausted after attempt ${event.attempt}${detail}`);
     }
+  }
+
+  /**
+   * Handle `summarization_retry_scheduled` session events.
+   *
+   * Fires when an auto-compaction's summary generation itself retries (the
+   * summarisation LLM call hit a transient failure). Mirrors `auto_retry_start`
+   * but for the compaction/branch-summary sub-flow, so operators have full
+   * retry visibility — without this, compaction-summary retries are invisible
+   * even though provider-call retries are logged.
+   *
+   * @param event - The summarization-retry-scheduled payload.
+   * @private
+   */
+  private handleSummarizationRetryScheduled(event: SummarizationRetryScheduledEvent): void {
+    this.logger.info(
+      `[summarization-retry] 🔄 summary generation retrying — attempt ` +
+        `${event.attempt}/${event.maxAttempts} after ${event.delayMs}ms ` +
+        `(last error: ${event.errorMessage})`
+    );
+  }
+
+  /**
+   * Handle `summarization_retry_attempt_start` session events.
+   *
+   * Fires at the start of each summarisation retry attempt. The `source`
+   * discriminates whether the summary being retried is a branch summary
+   * (tree navigation) or a compaction summary (context threshold/overflow).
+   * Logged at debug to avoid noise — the scheduled/finished pair already
+   * brackets the retry loop at info level.
+   *
+   * @param event - The summarization-retry-attempt-start payload.
+   * @private
+   */
+  private handleSummarizationRetryAttemptStart(event: SummarizationRetryAttemptStartEvent): void {
+    const reason = event.source === 'compaction' ? `compaction (${event.reason})` : 'branchSummary';
+    this.logger.debug(`[summarization-retry] ▶️ starting ${reason} summary attempt`);
+  }
+
+  /**
+   * Handle `summarization_retry_finished` session events.
+   *
+   * Fires when the summarisation retry loop settles. The SDK does not carry a
+   * success/error field on this event, so we log a plain info line that the
+   * retry loop resolved. Paired with {@link handleSummarizationRetryScheduled}
+   * this brackets the loop so operators can see it began and ended.
+   *
+   * @private
+   */
+  private handleSummarizationRetryFinished(): void {
+    this.logger.info(`[summarization-retry] ✅ summary retry loop finished`);
   }
 
   /**

--- a/packages/pi-orchestrator/src/pi/tools/create-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-pr.ts
@@ -14,36 +14,40 @@ import {
   CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_CREATE_PR } from './constants';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
 import type {
   CreatePullRequestParams,
   CreatePullRequestDetails,
   PlatformProvider,
 } from '../../platform';
-import { withCancellation } from './tool-execution';
+import { withCancellation, isPresent } from './tool-execution';
 
 /**
  * Schema for the create_pull_request tool.
  */
-const createPullRequestSchema = Type.Object({
-  title: Type.String({
-    description: CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
-  }),
-  body: Type.Optional(
-    Type.String({
-      description: CREATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
-    })
-  ),
-  base: Type.Optional(
-    Type.String({
-      description: CREATE_PULL_REQUEST_PARAM_BASE_DESCRIPTION,
-    })
-  ),
-  dryRun: Type.Optional(
-    Type.Boolean({
-      description: CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
-    })
-  ),
-});
+const createPullRequestSchema = Type.Object(
+  {
+    title: Type.String({
+      description: CREATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
+    }),
+    body: nullable(
+      Type.String({
+        description: CREATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
+      })
+    ),
+    base: nullable(
+      Type.String({
+        description: CREATE_PULL_REQUEST_PARAM_BASE_DESCRIPTION,
+      })
+    ),
+    dryRun: nullable(
+      Type.Boolean({
+        description: CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type CreatePullRequestToolParams = Static<typeof createPullRequestSchema>;
 
@@ -61,6 +65,7 @@ export function createPRToolFactory(provider: PlatformProvider) {
     promptSnippet: CREATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
     parameters: createPullRequestSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_CREATE_PR,
       cancellationDetails: {
@@ -73,13 +78,13 @@ export function createPRToolFactory(provider: PlatformProvider) {
       prepareParams: (params: CreatePullRequestToolParams) => {
         const { title, body, base, dryRun } = params;
         const prParams: CreatePullRequestParams = { title };
-        if (body !== undefined) {
+        if (isPresent(body)) {
           prParams.body = body;
         }
-        if (base !== undefined) {
+        if (isPresent(base)) {
           prParams.base = base;
         }
-        if (dryRun !== undefined) {
+        if (isPresent(dryRun)) {
           prParams.dryRun = dryRun;
         }
         return prParams;

--- a/packages/pi-orchestrator/src/pi/tools/create-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-pr.ts
@@ -14,7 +14,7 @@ import {
   CREATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_CREATE_PR } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import type {
   CreatePullRequestParams,
   CreatePullRequestDetails,
@@ -65,7 +65,7 @@ export function createPRToolFactory(provider: PlatformProvider) {
     promptSnippet: CREATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: CREATE_PULL_REQUEST_PROMPT_GUIDELINES,
     parameters: createPullRequestSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_CREATE_PR,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/create-review.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-review.ts
@@ -22,66 +22,73 @@ import {
   CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_CREATE_REVIEW } from './constants';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
 import type { CreateReviewParams, CreateReviewDetails, PlatformProvider } from '../../platform';
-import { withCancellation } from './tool-execution';
+import { withCancellation, isPresent } from './tool-execution';
 
 /**
  * Schema for a single inline review comment.
  */
-const reviewCommentSchema = Type.Object({
-  path: Type.String({
-    description: CREATE_REVIEW_PARAM_COMMENT_PATH_DESCRIPTION,
-  }),
-  line: Type.Integer({
-    description: CREATE_REVIEW_PARAM_COMMENT_LINE_DESCRIPTION,
-  }),
-  side: Type.Optional(
-    Type.Union([Type.Literal('LEFT'), Type.Literal('RIGHT')], {
-      description: CREATE_REVIEW_PARAM_COMMENT_SIDE_DESCRIPTION,
-    })
-  ),
-  start_line: Type.Optional(
-    Type.Integer({
-      description: CREATE_REVIEW_PARAM_COMMENT_START_LINE_DESCRIPTION,
-    })
-  ),
-  start_side: Type.Optional(
-    Type.Union([Type.Literal('LEFT'), Type.Literal('RIGHT')], {
-      description: CREATE_REVIEW_PARAM_COMMENT_START_SIDE_DESCRIPTION,
-    })
-  ),
-  body: Type.String({
-    description: CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION,
-  }),
-});
+const reviewCommentSchema = Type.Object(
+  {
+    path: Type.String({
+      description: CREATE_REVIEW_PARAM_COMMENT_PATH_DESCRIPTION,
+    }),
+    line: Type.Integer({
+      description: CREATE_REVIEW_PARAM_COMMENT_LINE_DESCRIPTION,
+    }),
+    side: nullable(
+      Type.Union([Type.Literal('LEFT'), Type.Literal('RIGHT')], {
+        description: CREATE_REVIEW_PARAM_COMMENT_SIDE_DESCRIPTION,
+      })
+    ),
+    start_line: nullable(
+      Type.Integer({
+        description: CREATE_REVIEW_PARAM_COMMENT_START_LINE_DESCRIPTION,
+      })
+    ),
+    start_side: nullable(
+      Type.Union([Type.Literal('LEFT'), Type.Literal('RIGHT')], {
+        description: CREATE_REVIEW_PARAM_COMMENT_START_SIDE_DESCRIPTION,
+      })
+    ),
+    body: Type.String({
+      description: CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION,
+    }),
+  },
+  { additionalProperties: false }
+);
 
 /**
  * Schema for the create_pull_request_review tool.
  */
-const createReviewSchema = Type.Object({
-  pull_number: Type.Optional(
-    Type.Integer({
-      description: CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION,
-    })
-  ),
-  body: Type.Optional(
-    Type.String({
-      description: CREATE_REVIEW_PARAM_BODY_DESCRIPTION,
-    })
-  ),
-  event: Type.Optional(
-    Type.Union(
-      [Type.Literal('COMMENT'), Type.Literal('APPROVE'), Type.Literal('REQUEST_CHANGES')],
-      {
-        description: CREATE_REVIEW_PARAM_EVENT_DESCRIPTION,
-      }
-    )
-  ),
-  comments: Type.Array(reviewCommentSchema, {
-    description:
-      'Array of inline comments anchored to diff lines. Each requires path, line, and body.',
-  }),
-});
+const createReviewSchema = Type.Object(
+  {
+    pull_number: nullable(
+      Type.Integer({
+        description: CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION,
+      })
+    ),
+    body: nullable(
+      Type.String({
+        description: CREATE_REVIEW_PARAM_BODY_DESCRIPTION,
+      })
+    ),
+    event: nullable(
+      Type.Union(
+        [Type.Literal('COMMENT'), Type.Literal('APPROVE'), Type.Literal('REQUEST_CHANGES')],
+        {
+          description: CREATE_REVIEW_PARAM_EVENT_DESCRIPTION,
+        }
+      )
+    ),
+    comments: Type.Array(reviewCommentSchema, {
+      description:
+        'Array of inline comments anchored to diff lines. Each requires path, line, and body.',
+    }),
+  },
+  { additionalProperties: false }
+);
 
 type CreateReviewToolParams = Static<typeof createReviewSchema>;
 
@@ -99,6 +106,7 @@ export function createReviewToolFactory(provider: PlatformProvider) {
     promptSnippet: CREATE_REVIEW_PROMPT_SNIPPET,
     promptGuidelines: CREATE_REVIEW_PROMPT_GUIDELINES,
     parameters: createReviewSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_CREATE_REVIEW,
       cancellationDetails: {
@@ -114,18 +122,18 @@ export function createReviewToolFactory(provider: PlatformProvider) {
             path: c.path,
             line: c.line,
             body: c.body,
-            ...(c.side !== undefined ? { side: c.side } : {}),
-            ...(c.start_line !== undefined ? { start_line: c.start_line } : {}),
-            ...(c.start_side !== undefined ? { start_side: c.start_side } : {}),
+            ...(isPresent(c.side) ? { side: c.side } : {}),
+            ...(isPresent(c.start_line) ? { start_line: c.start_line } : {}),
+            ...(isPresent(c.start_side) ? { start_side: c.start_side } : {}),
           })),
         };
-        if (params.pull_number !== undefined) {
+        if (isPresent(params.pull_number)) {
           reviewParams.pull_number = params.pull_number;
         }
-        if (params.body !== undefined) {
+        if (isPresent(params.body)) {
           reviewParams.body = params.body;
         }
-        if (params.event !== undefined) {
+        if (isPresent(params.event)) {
           reviewParams.event = params.event;
         }
         return reviewParams;

--- a/packages/pi-orchestrator/src/pi/tools/create-review.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-review.ts
@@ -22,7 +22,7 @@ import {
   CREATE_REVIEW_PARAM_COMMENT_BODY_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_CREATE_REVIEW } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import type { CreateReviewParams, CreateReviewDetails, PlatformProvider } from '../../platform';
 import { withCancellation, isPresent } from './tool-execution';
 
@@ -106,7 +106,7 @@ export function createReviewToolFactory(provider: PlatformProvider) {
     promptSnippet: CREATE_REVIEW_PROMPT_SNIPPET,
     promptGuidelines: CREATE_REVIEW_PROMPT_GUIDELINES,
     parameters: createReviewSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_CREATE_REVIEW,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
@@ -19,7 +19,7 @@ import {
   GET_CI_STATUS_PARAM_CONCLUSION_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_CI_STATUS } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import { withCancellation, isPresent } from './tool-execution';
 import type { PlatformProvider, GetCIStatusParams, GetCIStatusDetails } from '../../platform';
 
@@ -78,7 +78,7 @@ export function getCIStatusToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_CI_STATUS_PROMPT_SNIPPET,
     promptGuidelines: GET_CI_STATUS_PROMPT_GUIDELINES(provider.type),
     parameters: getCIStatusSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_CI_STATUS,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-ci-status.ts
@@ -19,44 +19,48 @@ import {
   GET_CI_STATUS_PARAM_CONCLUSION_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_CI_STATUS } from './constants';
-import { withCancellation } from './tool-execution';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { withCancellation, isPresent } from './tool-execution';
 import type { PlatformProvider, GetCIStatusParams, GetCIStatusDetails } from '../../platform';
 
 /**
  * Schema for the get_ci_status tool.
  */
-const getCIStatusSchema = Type.Object({
-  owner: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
-    })
-  ),
-  repo: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
-    })
-  ),
-  pull_number: Type.Optional(
-    Type.Integer({
-      description: GET_CI_STATUS_PARAM_PULL_NUMBER_DESCRIPTION,
-    })
-  ),
-  ref: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_REF_DESCRIPTION,
-    })
-  ),
-  status: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_STATUS_DESCRIPTION,
-    })
-  ),
-  conclusion: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_CONCLUSION_DESCRIPTION,
-    })
-  ),
-});
+const getCIStatusSchema = Type.Object(
+  {
+    owner: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
+      })
+    ),
+    repo: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
+      })
+    ),
+    pull_number: nullable(
+      Type.Integer({
+        description: GET_CI_STATUS_PARAM_PULL_NUMBER_DESCRIPTION,
+      })
+    ),
+    ref: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_REF_DESCRIPTION,
+      })
+    ),
+    status: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_STATUS_DESCRIPTION,
+      })
+    ),
+    conclusion: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_CONCLUSION_DESCRIPTION,
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type GetCIStatusToolParams = Static<typeof getCIStatusSchema>;
 
@@ -74,6 +78,7 @@ export function getCIStatusToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_CI_STATUS_PROMPT_SNIPPET,
     promptGuidelines: GET_CI_STATUS_PROMPT_GUIDELINES(provider.type),
     parameters: getCIStatusSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_CI_STATUS,
       cancellationDetails: {
@@ -83,12 +88,12 @@ export function getCIStatusToolFactory(provider: PlatformProvider) {
       },
       // fallow-ignore-next-line complexity
       prepareParams: (params: GetCIStatusToolParams): GetCIStatusParams => ({
-        ...(params.owner !== undefined ? { owner: params.owner } : {}),
-        ...(params.repo !== undefined ? { repo: params.repo } : {}),
-        ...(params.pull_number !== undefined ? { pull_number: params.pull_number } : {}),
-        ...(params.ref !== undefined ? { ref: params.ref } : {}),
-        ...(params.status !== undefined ? { status: params.status } : {}),
-        ...(params.conclusion !== undefined ? { conclusion: params.conclusion } : {}),
+        ...(isPresent(params.owner) ? { owner: params.owner } : {}),
+        ...(isPresent(params.repo) ? { repo: params.repo } : {}),
+        ...(isPresent(params.pull_number) ? { pull_number: params.pull_number } : {}),
+        ...(isPresent(params.ref) ? { ref: params.ref } : {}),
+        ...(isPresent(params.status) ? { status: params.status } : {}),
+        ...(isPresent(params.conclusion) ? { conclusion: params.conclusion } : {}),
       }),
       execute: async (params: GetCIStatusParams) =>
         provider.getCIStatus(params) as Promise<{

--- a/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
@@ -25,6 +25,7 @@ import {
   GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_PR_DIFF } from './constants';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
 import { withCancellation } from './tool-execution';
 import type { PlatformProvider } from '../../platform';
 import type { DiffConfig } from '../../types';
@@ -32,38 +33,41 @@ import type { DiffConfig } from '../../types';
 /**
  * Schema for the get_pr_diff tool.
  */
-const getPRDiffSchema = Type.Object({
-  owner: Type.Optional(
-    Type.String({
-      description: GET_PR_DIFF_PARAM_OWNER_DESCRIPTION,
-    })
-  ),
-  repo: Type.Optional(
-    Type.String({
-      description: GET_PR_DIFF_PARAM_REPO_DESCRIPTION,
-    })
-  ),
-  pull_number: Type.Optional(
-    Type.Integer({
-      description: GET_PR_DIFF_PARAM_PULL_NUMBER_DESCRIPTION,
-    })
-  ),
-  max_lines: Type.Optional(
-    Type.Integer({
-      description: GET_PR_DIFF_PARAM_MAX_LINES_DESCRIPTION,
-    })
-  ),
-  ignore_files: Type.Optional(
-    Type.Array(
+const getPRDiffSchema = Type.Object(
+  {
+    owner: nullable(
       Type.String({
-        description: GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
-      }),
-      {
-        description: GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
-      }
-    )
-  ),
-});
+        description: GET_PR_DIFF_PARAM_OWNER_DESCRIPTION,
+      })
+    ),
+    repo: nullable(
+      Type.String({
+        description: GET_PR_DIFF_PARAM_REPO_DESCRIPTION,
+      })
+    ),
+    pull_number: nullable(
+      Type.Integer({
+        description: GET_PR_DIFF_PARAM_PULL_NUMBER_DESCRIPTION,
+      })
+    ),
+    max_lines: nullable(
+      Type.Integer({
+        description: GET_PR_DIFF_PARAM_MAX_LINES_DESCRIPTION,
+      })
+    ),
+    ignore_files: nullable(
+      Type.Array(
+        Type.String({
+          description: GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
+        }),
+        {
+          description: GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
+        }
+      )
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type GetPRDiffToolParams = Static<typeof getPRDiffSchema>;
 
@@ -307,6 +311,7 @@ export function getPRDiffToolFactory(provider: PlatformProvider, config?: DiffCo
     promptSnippet: GET_PR_DIFF_PROMPT_SNIPPET,
     promptGuidelines: GET_PR_DIFF_PROMPT_GUIDELINES(provider.type),
     parameters: getPRDiffSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation<GetPRDiffToolParams, GetPRDiffDetails, GetPRDiffToolParams>({
       cancellationMessage: CANCELLATION_MESSAGE_GET_PR_DIFF,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-pr-diff.ts
@@ -25,7 +25,7 @@ import {
   GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_PR_DIFF } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import { withCancellation } from './tool-execution';
 import type { PlatformProvider } from '../../platform';
 import type { DiffConfig } from '../../types';
@@ -311,7 +311,7 @@ export function getPRDiffToolFactory(provider: PlatformProvider, config?: DiffCo
     promptSnippet: GET_PR_DIFF_PROMPT_SNIPPET,
     promptGuidelines: GET_PR_DIFF_PROMPT_GUIDELINES(provider.type),
     parameters: getPRDiffSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation<GetPRDiffToolParams, GetPRDiffDetails, GetPRDiffToolParams>({
       cancellationMessage: CANCELLATION_MESSAGE_GET_PR_DIFF,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/get-thread.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-thread.ts
@@ -14,36 +14,40 @@ import {
   GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_THREAD } from './constants';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
 import { formatThreadAsText } from './common';
 import type { IssueOrPRThread, GetIssueOrPRThreadParams, PlatformProvider } from '../../platform';
 import type { AgentToolResult } from '@earendil-works/pi-coding-agent';
-import { withCancellation } from './tool-execution';
+import { withCancellation, isPresent } from './tool-execution';
 
 /**
  * Schema for the get_issue_or_pr_thread tool.
  */
-const getIssueOrPRThreadSchema = Type.Object({
-  owner: Type.Optional(
-    Type.String({
-      description: GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION,
-    })
-  ),
-  repo: Type.Optional(
-    Type.String({
-      description: GET_ISSUE_PR_THREAD_PARAM_REPO_DESCRIPTION,
-    })
-  ),
-  issue_number: Type.Optional(
-    Type.Integer({
-      description: GET_ISSUE_PR_THREAD_PARAM_ISSUE_NUMBER_DESCRIPTION,
-    })
-  ),
-  max_comments: Type.Optional(
-    Type.Integer({
-      description: GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION,
-    })
-  ),
-});
+const getIssueOrPRThreadSchema = Type.Object(
+  {
+    owner: nullable(
+      Type.String({
+        description: GET_ISSUE_PR_THREAD_PARAM_OWNER_DESCRIPTION,
+      })
+    ),
+    repo: nullable(
+      Type.String({
+        description: GET_ISSUE_PR_THREAD_PARAM_REPO_DESCRIPTION,
+      })
+    ),
+    issue_number: nullable(
+      Type.Integer({
+        description: GET_ISSUE_PR_THREAD_PARAM_ISSUE_NUMBER_DESCRIPTION,
+      })
+    ),
+    max_comments: nullable(
+      Type.Integer({
+        description: GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION,
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type GetIssueOrPRThreadToolParams = Static<typeof getIssueOrPRThreadSchema>;
 
@@ -89,6 +93,7 @@ export function getIssueOrPRThreadToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_ISSUE_PR_THREAD_PROMPT_SNIPPET(provider.type),
     promptGuidelines: GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES(provider.type),
     parameters: getIssueOrPRThreadSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_THREAD,
       cancellationDetails: {
@@ -110,7 +115,12 @@ export function getIssueOrPRThreadToolFactory(provider: PlatformProvider) {
         comments: [],
         review_comments: [],
       },
-      prepareParams: (params: GetIssueOrPRThreadToolParams) => params,
+      prepareParams: (params: GetIssueOrPRThreadToolParams): GetIssueOrPRThreadParams => ({
+        ...(isPresent(params.owner) ? { owner: params.owner } : {}),
+        ...(isPresent(params.repo) ? { repo: params.repo } : {}),
+        ...(isPresent(params.issue_number) ? { issue_number: params.issue_number } : {}),
+        ...(isPresent(params.max_comments) ? { max_comments: params.max_comments } : {}),
+      }),
       execute: async (params: GetIssueOrPRThreadParams) => {
         const result = await provider.getIssueOrPRThread(params);
 

--- a/packages/pi-orchestrator/src/pi/tools/get-thread.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-thread.ts
@@ -14,7 +14,7 @@ import {
   GET_ISSUE_PR_THREAD_PARAM_MAX_COMMENTS_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_THREAD } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import { formatThreadAsText } from './common';
 import type { IssueOrPRThread, GetIssueOrPRThreadParams, PlatformProvider } from '../../platform';
 import type { AgentToolResult } from '@earendil-works/pi-coding-agent';
@@ -93,7 +93,7 @@ export function getIssueOrPRThreadToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_ISSUE_PR_THREAD_PROMPT_SNIPPET(provider.type),
     promptGuidelines: GET_ISSUE_PR_THREAD_PROMPT_GUIDELINES(provider.type),
     parameters: getIssueOrPRThreadSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_THREAD,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
@@ -17,7 +17,8 @@ import {
   GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_WORKFLOW_RUN_LOGS } from './constants';
-import { withCancellation } from './tool-execution';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { withCancellation, isPresent } from './tool-execution';
 import type {
   PlatformProvider,
   GetWorkflowRunLogsParams,
@@ -27,26 +28,29 @@ import type {
 /**
  * Schema for the get_workflow_run_logs tool.
  */
-const getWorkflowRunLogsSchema = Type.Object({
-  owner: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
-    })
-  ),
-  repo: Type.Optional(
-    Type.String({
-      description: GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
-    })
-  ),
-  run_id: Type.Integer({
-    description: GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION,
-  }),
-  max_bytes: Type.Optional(
-    Type.Integer({
-      description: GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
-    })
-  ),
-});
+const getWorkflowRunLogsSchema = Type.Object(
+  {
+    owner: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_OWNER_DESCRIPTION,
+      })
+    ),
+    repo: nullable(
+      Type.String({
+        description: GET_CI_STATUS_PARAM_REPO_DESCRIPTION,
+      })
+    ),
+    run_id: Type.Integer({
+      description: GET_WORKFLOW_RUN_LOGS_PARAM_RUN_ID_DESCRIPTION,
+    }),
+    max_bytes: nullable(
+      Type.Integer({
+        description: GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type GetWorkflowRunLogsToolParams = Static<typeof getWorkflowRunLogsSchema>;
 
@@ -64,6 +68,7 @@ export function getWorkflowRunLogsToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
     promptGuidelines: GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
     parameters: getWorkflowRunLogsSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_WORKFLOW_RUN_LOGS,
       cancellationDetails: {
@@ -73,10 +78,10 @@ export function getWorkflowRunLogsToolFactory(provider: PlatformProvider) {
         truncated: false,
       },
       prepareParams: (params: GetWorkflowRunLogsToolParams): GetWorkflowRunLogsParams => ({
-        ...(params.owner !== undefined ? { owner: params.owner } : {}),
-        ...(params.repo !== undefined ? { repo: params.repo } : {}),
+        ...(isPresent(params.owner) ? { owner: params.owner } : {}),
+        ...(isPresent(params.repo) ? { repo: params.repo } : {}),
         run_id: params.run_id,
-        ...(params.max_bytes !== undefined ? { max_bytes: params.max_bytes } : {}),
+        ...(isPresent(params.max_bytes) ? { max_bytes: params.max_bytes } : {}),
       }),
       execute: async (params: GetWorkflowRunLogsParams) =>
         provider.getWorkflowRunLogs(params) as Promise<{

--- a/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
+++ b/packages/pi-orchestrator/src/pi/tools/get-workflow-run-logs.ts
@@ -17,7 +17,7 @@ import {
   GET_WORKFLOW_RUN_LOGS_PARAM_MAX_BYTES_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_GET_WORKFLOW_RUN_LOGS } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import { withCancellation, isPresent } from './tool-execution';
 import type {
   PlatformProvider,
@@ -68,7 +68,7 @@ export function getWorkflowRunLogsToolFactory(provider: PlatformProvider) {
     promptSnippet: GET_WORKFLOW_RUN_LOGS_PROMPT_SNIPPET,
     promptGuidelines: GET_WORKFLOW_RUN_LOGS_PROMPT_GUIDELINES,
     parameters: getWorkflowRunLogsSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_GET_WORKFLOW_RUN_LOGS,
       cancellationDetails: {

--- a/packages/pi-orchestrator/src/pi/tools/schema.ts
+++ b/packages/pi-orchestrator/src/pi/tools/schema.ts
@@ -2,7 +2,7 @@
  * @file TypeBox schema helpers for strict JSON-schema tool definitions.
  *
  * Our custom tools opt into provider-side strict JSON-schema sampling via
- * {@link STRICT_JSON_SCHEMA}. Both OpenAI and Anthropic strict mode require
+ * {@link PREFER_STRICT_JSON_SCHEMA}. Both OpenAI and Anthropic strict mode require
  * the tool parameter schema to:
  *
  * 1. Set `additionalProperties: false` on every object, and
@@ -46,17 +46,18 @@ export function nullable<T extends TSchema>(schema: T) {
 /**
  * Request provider-side strict JSON-schema enforcement for a tool.
  *
- * `strict: 'prefer'` (not `'require'`) so models/providers without strict-mode
- * support fall back to normal tool calling instead of failing the request. On
- * strict-capable models (OpenAI GPT-5 family, Anthropic Claude, Bedrock
- * Converse, Mistral, Gemini 3) the provider enforces the JSON schema
- * server-side, reducing malformed tool-call arguments.
+ * The constant name reflects the configured `strict: 'prefer'` (not
+ * `'require'`): models/providers without strict-mode support fall back to
+ * normal tool calling instead of failing the request. On strict-capable models
+ * (OpenAI GPT-5 family, Anthropic Claude, Bedrock Converse, Mistral, Gemini 3)
+ * the provider enforces the JSON schema server-side, reducing malformed
+ * tool-call arguments.
  *
  * Pair with `additionalProperties: false` and {@link nullable} optionals so the
  * schema is strict-compatible; otherwise strict-capable providers reject the
  * request.
  */
-export const STRICT_JSON_SCHEMA = {
+export const PREFER_STRICT_JSON_SCHEMA = {
   type: 'json_schema',
   strict: 'prefer',
 } as const;

--- a/packages/pi-orchestrator/src/pi/tools/schema.ts
+++ b/packages/pi-orchestrator/src/pi/tools/schema.ts
@@ -1,0 +1,62 @@
+/**
+ * @file TypeBox schema helpers for strict JSON-schema tool definitions.
+ *
+ * Our custom tools opt into provider-side strict JSON-schema sampling via
+ * {@link STRICT_JSON_SCHEMA}. Both OpenAI and Anthropic strict mode require
+ * the tool parameter schema to:
+ *
+ * 1. Set `additionalProperties: false` on every object, and
+ * 2. List **every** property in `required` — optional properties are not
+ *    allowed. Optional fields must instead be modelled as a required-but-
+ *    nullable union (`type: ["string", "null"]`, emitted by TypeBox as
+ *    `anyOf: [{type:"string"}, {type:"null"}]`).
+ *
+ * The SDK passes the TypeBox schema to the provider as-is (it does **not**
+ * transform optionals into nullables), so the strict-compatible shape must be
+ * authored here. `nullable()` makes that mechanical and consistent.
+ *
+ * See the Pi SDK "Constrained Sampling for Tools" docs.
+ */
+
+import { Type, type TSchema } from 'typebox';
+
+/**
+ * Wrap a schema in a required-but-nullable union.
+ *
+ * Produces `anyOf: [<schema>, { type: "null" }]`, which OpenAI and Anthropic
+ * strict modes accept for optional fields. The resulting property is **required**
+ * (it appears in the object's `required` array); callers should treat a `null`
+ * value as "absent" at the tool boundary (e.g. via the `isPresent()` guard).
+ *
+ * @param schema - The inner TypeBox schema (e.g. `Type.String()`).
+ * @returns A nullable union schema usable directly as an object property.
+ *
+ * @example
+ * ```typescript
+ * const schema = Type.Object({
+ *   title: Type.String(),
+ *   body: nullable(Type.String()),   // required, but `string | null`
+ * }, { additionalProperties: false });
+ * ```
+ */
+export function nullable<T extends TSchema>(schema: T) {
+  return Type.Union([schema, Type.Null()]);
+}
+
+/**
+ * Request provider-side strict JSON-schema enforcement for a tool.
+ *
+ * `strict: 'prefer'` (not `'require'`) so models/providers without strict-mode
+ * support fall back to normal tool calling instead of failing the request. On
+ * strict-capable models (OpenAI GPT-5 family, Anthropic Claude, Bedrock
+ * Converse, Mistral, Gemini 3) the provider enforces the JSON schema
+ * server-side, reducing malformed tool-call arguments.
+ *
+ * Pair with `additionalProperties: false` and {@link nullable} optionals so the
+ * schema is strict-compatible; otherwise strict-capable providers reject the
+ * request.
+ */
+export const STRICT_JSON_SCHEMA = {
+  type: 'json_schema',
+  strict: 'prefer',
+} as const;

--- a/packages/pi-orchestrator/src/pi/tools/tool-execution.ts
+++ b/packages/pi-orchestrator/src/pi/tools/tool-execution.ts
@@ -12,6 +12,22 @@ import type {
 } from '@earendil-works/pi-coding-agent';
 
 /**
+ * Type guard: true when `value` is neither `null` nor `undefined`.
+ *
+ * Strict-capable providers (OpenAI/Anthropic strict tool sampling) emit `null`
+ * for absent optional tool fields — our schemas model optionals as required-
+ * but-nullable via `nullable()`. Models without strict support may omit the key
+ * entirely (`undefined`). This guard normalises both so `prepareParams` can
+ * drop absent fields uniformly regardless of the provider.
+ *
+ * Uses strict `!==` checks (no loose `!=`) to satisfy the `eqeqeq` lint rule
+ * while still covering both nullish cases.
+ */
+export function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+/**
  * Result of a cancelled tool execution.
  */
 export interface CancellationResult<TDetails> {

--- a/packages/pi-orchestrator/src/pi/tools/update-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/update-pr.ts
@@ -15,43 +15,47 @@ import {
   UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_UPDATE_PR } from './constants';
+import { nullable, STRICT_JSON_SCHEMA } from './schema';
 import type {
   UpdatePullRequestParams,
   UpdatePullRequestDetails,
   PlatformProvider,
 } from '../../platform';
-import { withCancellation } from './tool-execution';
+import { withCancellation, isPresent } from './tool-execution';
 
 /**
  * Schema for the update_pull_request tool.
  */
-const updatePullRequestSchema = Type.Object({
-  pull_number: Type.Optional(
-    Type.Integer({
-      description: UPDATE_PULL_REQUEST_PARAM_PULL_NUMBER_DESCRIPTION,
-    })
-  ),
-  title: Type.Optional(
-    Type.String({
-      description: UPDATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
-    })
-  ),
-  body: Type.Optional(
-    Type.String({
-      description: UPDATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
-    })
-  ),
-  message: Type.Optional(
-    Type.String({
-      description: UPDATE_PULL_REQUEST_PARAM_MESSAGE_DESCRIPTION,
-    })
-  ),
-  dryRun: Type.Optional(
-    Type.Boolean({
-      description: UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
-    })
-  ),
-});
+const updatePullRequestSchema = Type.Object(
+  {
+    pull_number: nullable(
+      Type.Integer({
+        description: UPDATE_PULL_REQUEST_PARAM_PULL_NUMBER_DESCRIPTION,
+      })
+    ),
+    title: nullable(
+      Type.String({
+        description: UPDATE_PULL_REQUEST_PARAM_TITLE_DESCRIPTION,
+      })
+    ),
+    body: nullable(
+      Type.String({
+        description: UPDATE_PULL_REQUEST_PARAM_BODY_DESCRIPTION,
+      })
+    ),
+    message: nullable(
+      Type.String({
+        description: UPDATE_PULL_REQUEST_PARAM_MESSAGE_DESCRIPTION,
+      })
+    ),
+    dryRun: nullable(
+      Type.Boolean({
+        description: UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 type UpdatePullRequestToolParams = Static<typeof updatePullRequestSchema>;
 
@@ -69,6 +73,7 @@ export function updatePullRequestToolFactory(provider: PlatformProvider) {
     promptSnippet: UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: UPDATE_PULL_REQUEST_PROMPT_GUIDELINES(provider.type),
     parameters: updatePullRequestSchema,
+    constrainedSampling: STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_UPDATE_PR,
       cancellationDetails: {
@@ -82,19 +87,19 @@ export function updatePullRequestToolFactory(provider: PlatformProvider) {
       prepareParams: (params: UpdatePullRequestToolParams) => {
         const { pull_number, title, body, message, dryRun } = params;
         const updateParams: UpdatePullRequestParams = {};
-        if (pull_number !== undefined) {
+        if (isPresent(pull_number)) {
           updateParams.pull_number = pull_number;
         }
-        if (title !== undefined) {
+        if (isPresent(title)) {
           updateParams.title = title;
         }
-        if (body !== undefined) {
+        if (isPresent(body)) {
           updateParams.body = body;
         }
-        if (message !== undefined) {
+        if (isPresent(message)) {
           updateParams.message = message;
         }
-        if (dryRun !== undefined) {
+        if (isPresent(dryRun)) {
           updateParams.dryRun = dryRun;
         }
         return updateParams;

--- a/packages/pi-orchestrator/src/pi/tools/update-pr.ts
+++ b/packages/pi-orchestrator/src/pi/tools/update-pr.ts
@@ -15,7 +15,7 @@ import {
   UPDATE_PULL_REQUEST_PARAM_DRY_RUN_DESCRIPTION,
 } from '../prompt';
 import { CANCELLATION_MESSAGE_UPDATE_PR } from './constants';
-import { nullable, STRICT_JSON_SCHEMA } from './schema';
+import { nullable, PREFER_STRICT_JSON_SCHEMA } from './schema';
 import type {
   UpdatePullRequestParams,
   UpdatePullRequestDetails,
@@ -73,7 +73,7 @@ export function updatePullRequestToolFactory(provider: PlatformProvider) {
     promptSnippet: UPDATE_PULL_REQUEST_PROMPT_SNIPPET,
     promptGuidelines: UPDATE_PULL_REQUEST_PROMPT_GUIDELINES(provider.type),
     parameters: updatePullRequestSchema,
-    constrainedSampling: STRICT_JSON_SCHEMA,
+    constrainedSampling: PREFER_STRICT_JSON_SCHEMA,
     execute: withCancellation({
       cancellationMessage: CANCELLATION_MESSAGE_UPDATE_PR,
       cancellationDetails: {

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -823,7 +823,7 @@ describe('Agent', () => {
 
       await agent.run('Hello');
 
-      const finishedLine = infoMessages.find(m => m.startsWith('[summarization-retry] ✅'));
+      const finishedLine = infoMessages.find(m => m.startsWith('[summarization-retry] •'));
       expect(finishedLine).toBeDefined();
       expect(finishedLine).toContain('finished');
     });

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { resolve } from 'node:path';
 import { buildMockSession, injectMockSession, userHelloMessage } from './helpers/agent-session';
+import type { MockSession, MockSessionEvent } from './helpers/agent-session';
 import { createMockProvider } from '../helpers/tool-mocks';
 
 /**
@@ -639,6 +640,119 @@ describe('Agent', () => {
 
       const result = await agent.run('Hello');
       expect(result.error).toBe('429 rate limit');
+    });
+  });
+
+  /**
+   * Build a mock session that dispatches an arbitrary sequence of raw
+   * `AgentSessionEvent`s through the agent's registered handler when
+   * `prompt()` is called. Used to exercise events (e.g. `auto_retry_*`)
+   * that arrive on the session stream rather than the ExtensionAPI.
+   */
+  function buildRawEventSession(events: MockSessionEvent[]): MockSession {
+    let listener: ((event: MockSessionEvent) => void) | undefined;
+    return {
+      getSessionStats: () => ({ tokens: { input: 0, output: 0, total: 0 }, cost: 0 }),
+      prompt: async () => {
+        for (const event of events) {
+          listener?.(event);
+        }
+      },
+      subscribe: (cb: (event: MockSessionEvent) => void) => {
+        listener = cb;
+      },
+      state: { messages: [] },
+    };
+  }
+
+  describe('auto_retry event handling', () => {
+    test('auto_retry_start logs an info line with attempt/maxAttempts/delay/error', async () => {
+      const { core: testCore, messages: infoMessages } = createCoreWithInfoCapture();
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([
+          {
+            type: 'auto_retry_start',
+            attempt: 1,
+            maxAttempts: 3,
+            delayMs: 1500,
+            errorMessage: '503 overloaded',
+          },
+          { type: 'auto_retry_end', success: true, attempt: 1 },
+          { type: 'agent_settled' },
+        ])
+      );
+
+      await agent.run('Hello');
+
+      const retryLine = infoMessages.find(m => m.startsWith('[auto-retry] 🔄'));
+      expect(retryLine).toBeDefined();
+      expect(retryLine).toContain('attempt 1/3');
+      expect(retryLine).toContain('1500ms');
+      expect(retryLine).toContain('503 overloaded');
+    });
+
+    test('auto_retry_end success logs an info recovery line', async () => {
+      const { core: testCore, messages: infoMessages } = createCoreWithInfoCapture();
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([
+          {
+            type: 'auto_retry_start',
+            attempt: 2,
+            maxAttempts: 3,
+            delayMs: 0,
+            errorMessage: 'transient',
+          },
+          { type: 'auto_retry_end', success: true, attempt: 2 },
+          { type: 'agent_settled' },
+        ])
+      );
+
+      await agent.run('Hello');
+
+      const recoveredLine = infoMessages.find(m => m.startsWith('[auto-retry] ✅'));
+      expect(recoveredLine).toBeDefined();
+      expect(recoveredLine).toContain('attempt 2');
+    });
+
+    test('auto_retry_end failure logs a warning with the final error', async () => {
+      const { core: testCore, messages: warnings } = createCoreWithWarningCapture();
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([
+          {
+            type: 'auto_retry_start',
+            attempt: 3,
+            maxAttempts: 3,
+            delayMs: 0,
+            errorMessage: 'still failing',
+          },
+          {
+            type: 'auto_retry_end',
+            success: false,
+            attempt: 3,
+            finalError: 'connection reset',
+          },
+          { type: 'agent_settled' },
+        ])
+      );
+
+      await agent.run('Hello');
+
+      const exhaustedLine = warnings.find(m => m.startsWith('[auto-retry] ❌'));
+      expect(exhaustedLine).toBeDefined();
+      expect(exhaustedLine).toContain('attempt 3');
+      expect(exhaustedLine).toContain('connection reset');
     });
   });
 

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -756,6 +756,79 @@ describe('Agent', () => {
     });
   });
 
+  describe('summarization_retry event handling', () => {
+    test('summarization_retry_scheduled logs an info line with attempt/maxAttempts/delay/error', async () => {
+      const { core: testCore, messages: infoMessages } = createCoreWithInfoCapture();
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([
+          {
+            type: 'summarization_retry_scheduled',
+            attempt: 1,
+            maxAttempts: 2,
+            delayMs: 800,
+            errorMessage: 'summary timeout',
+          },
+          { type: 'summarization_retry_finished' },
+          { type: 'agent_settled' },
+        ])
+      );
+
+      await agent.run('Hello');
+
+      const retryLine = infoMessages.find(m => m.startsWith('[summarization-retry] 🔄'));
+      expect(retryLine).toBeDefined();
+      expect(retryLine).toContain('attempt 1/2');
+      expect(retryLine).toContain('800ms');
+      expect(retryLine).toContain('summary timeout');
+    });
+
+    test('summarization_retry_attempt_start logs a debug line naming the source', async () => {
+      const debug = vi.fn();
+      const testCore = { ...mockCoreAdapter, debug };
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([
+          { type: 'summarization_retry_attempt_start', source: 'compaction', reason: 'overflow' },
+          { type: 'agent_settled' },
+        ])
+      );
+
+      await agent.run('Hello');
+
+      const debugLine = debug.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' && (c[0] as string).startsWith('[summarization-retry] ▶️')
+      );
+      expect(debugLine).toBeDefined();
+      expect(debugLine![0]).toContain('compaction');
+      expect(debugLine![0]).toContain('overflow');
+    });
+
+    test('summarization_retry_finished logs an info line', async () => {
+      const { core: testCore, messages: infoMessages } = createCoreWithInfoCapture();
+      const agent = new Agent(testCore as any, mockPlatformProvider, defaultAgentConfig);
+      await agent.ready();
+
+      injectMockSession(
+        agent,
+        buildRawEventSession([{ type: 'summarization_retry_finished' }, { type: 'agent_settled' }])
+      );
+
+      await agent.run('Hello');
+
+      const finishedLine = infoMessages.find(m => m.startsWith('[summarization-retry] ✅'));
+      expect(finishedLine).toBeDefined();
+      expect(finishedLine).toContain('finished');
+    });
+  });
+
   describe('loadedTools validation', () => {
     test('throws error when loadedTools contains unknown tool names', async () => {
       const agent = new Agent(mockCoreAdapter as any, mockPlatformProvider, {

--- a/packages/pi-orchestrator/tests/pi/tools.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/tools.spec.ts
@@ -40,9 +40,11 @@ interface TestTool {
   promptGuidelines: string[];
   promptSnippet: string;
   parameters: {
-    properties: Record<string, { type: string }>;
+    properties: Record<string, { type?: string; anyOf?: { type?: string }[] }>;
     required?: string[];
+    additionalProperties?: boolean;
   };
+  constrainedSampling?: { type: string; strict: string };
   execute: (
     _toolCallId: string,
     params: Record<string, unknown>,
@@ -70,6 +72,34 @@ function captureRegisteredTools() {
 
 function getToolByName(tools: TestTool[], name: string): TestTool | undefined {
   return tools.find(t => t.name === name);
+}
+
+/**
+ * Assert a tool field is required-but-nullable — the strict-compatible form
+ * for what used to be an optional property. Strict JSON-schema sampling
+ * (OpenAI/Anthropic) forbids optionals, so absent values are modelled as a
+ * required union with null (`anyOf: [<type>, { type: 'null' }]`).
+ */
+function expectRequiredNullable(tool: TestTool, field: string): void {
+  const prop = tool.parameters.properties[field];
+  expect(prop).toBeDefined();
+  expect(tool.parameters.required).toContain(field);
+  expect(prop?.anyOf?.some(member => member.type === 'null')).toBe(true);
+}
+
+/**
+ * Assert a tool's schema is strict-compatible and opts into strict sampling:
+ * `additionalProperties: false`, every property listed in `required`, and the
+ * `constrainedSampling` config set to `prefer`.
+ */
+function expectStrictTool(tool: TestTool): void {
+  expect(tool.parameters.additionalProperties).toBe(false);
+  const keys = Object.keys(tool.parameters.properties);
+  expect(keys.length).toBeGreaterThan(0);
+  for (const key of keys) {
+    expect(tool.parameters.required).toContain(key);
+  }
+  expect(tool.constrainedSampling).toEqual({ type: 'json_schema', strict: 'prefer' });
 }
 
 describe('extFactory', () => {
@@ -175,22 +205,20 @@ describe('extFactory', () => {
     expect(params.properties.title?.type).toBe('string');
   });
 
-  test('create_pull_request parameters body is optional', () => {
-    const params = createPRTool.parameters;
-    expect(params.properties.body).toBeDefined();
-    expect(params.required).not.toContain('body');
+  test('create_pull_request parameters body is required-but-nullable', () => {
+    expectRequiredNullable(createPRTool, 'body');
   });
 
-  test('create_pull_request parameters base is optional', () => {
-    const params = createPRTool.parameters;
-    expect(params.properties.base).toBeDefined();
-    expect(params.required).not.toContain('base');
+  test('create_pull_request parameters base is required-but-nullable', () => {
+    expectRequiredNullable(createPRTool, 'base');
   });
 
-  test('create_pull_request parameters dryRun is optional', () => {
-    const params = createPRTool.parameters;
-    expect(params.properties.dryRun).toBeDefined();
-    expect(params.required).not.toContain('dryRun');
+  test('create_pull_request parameters dryRun is required-but-nullable', () => {
+    expectRequiredNullable(createPRTool, 'dryRun');
+  });
+
+  test('create_pull_request schema is strict-compatible (additionalProperties:false, strict sampling)', () => {
+    expectStrictTool(createPRTool);
   });
 
   test('create_pull_request title is required', () => {
@@ -198,76 +226,44 @@ describe('extFactory', () => {
     expect(params.required).toContain('title');
   });
 
-  test('update_pull_request parameters pull_number is optional', () => {
-    const params = updatePRTool.parameters;
-    expect(params.properties.pull_number).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('pull_number');
-    }
+  test('update_pull_request parameters pull_number is required-but-nullable', () => {
+    expectRequiredNullable(updatePRTool, 'pull_number');
   });
 
-  test('update_pull_request parameters title is optional', () => {
-    const params = updatePRTool.parameters;
-    expect(params.properties.title).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('title');
-    }
+  test('update_pull_request parameters title is required-but-nullable', () => {
+    expectRequiredNullable(updatePRTool, 'title');
   });
 
-  test('update_pull_request parameters body is optional', () => {
-    const params = updatePRTool.parameters;
-    expect(params.properties.body).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('body');
-    }
+  test('update_pull_request parameters body is required-but-nullable', () => {
+    expectRequiredNullable(updatePRTool, 'body');
   });
 
-  test('update_pull_request parameters dryRun is optional', () => {
-    const params = updatePRTool.parameters;
-    expect(params.properties.dryRun).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('dryRun');
-    }
+  test('update_pull_request parameters dryRun is required-but-nullable', () => {
+    expectRequiredNullable(updatePRTool, 'dryRun');
   });
 
-  test('get_issue_or_pr_thread parameters owner is optional', () => {
-    const params = getIssuePRThreadTool.parameters;
-    expect(params.properties.owner).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('owner');
-    }
+  test('update_pull_request schema is strict-compatible (additionalProperties:false, strict sampling)', () => {
+    expectStrictTool(updatePRTool);
   });
 
-  test('get_issue_or_pr_thread parameters repo is optional', () => {
-    const params = getIssuePRThreadTool.parameters;
-    expect(params.properties.repo).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('repo');
-    }
+  test('get_issue_or_pr_thread parameters owner is required-but-nullable', () => {
+    expectRequiredNullable(getIssuePRThreadTool, 'owner');
   });
 
-  test('get_issue_or_pr_thread parameters issue_number is optional', () => {
-    const params = getIssuePRThreadTool.parameters;
-    expect(params.properties.issue_number).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('issue_number');
-    }
+  test('get_issue_or_pr_thread parameters repo is required-but-nullable', () => {
+    expectRequiredNullable(getIssuePRThreadTool, 'repo');
   });
 
-  test('get_issue_or_pr_thread parameters max_comments is optional', () => {
-    const params = getIssuePRThreadTool.parameters;
-    expect(params.properties.max_comments).toBeDefined();
-    // When all fields are optional, required may be undefined
-    if (Array.isArray(params.required)) {
-      expect(params.required).not.toContain('max_comments');
-    }
+  test('get_issue_or_pr_thread parameters issue_number is required-but-nullable', () => {
+    expectRequiredNullable(getIssuePRThreadTool, 'issue_number');
+  });
+
+  test('get_issue_or_pr_thread parameters max_comments is required-but-nullable', () => {
+    expectRequiredNullable(getIssuePRThreadTool, 'max_comments');
+  });
+
+  test('get_issue_or_pr_thread schema is strict-compatible (additionalProperties:false, strict sampling)', () => {
+    expectStrictTool(getIssuePRThreadTool);
   });
 
   describe('create_pull_request execute', () => {
@@ -354,16 +350,15 @@ describe('extFactory', () => {
       expect(getPRDiffTool.promptSnippet.length).toBeGreaterThan(0);
     });
 
-    test('parameters - all fields are optional', () => {
+    test('parameters - all fields are present and the schema is strict-compatible', () => {
       const params = getPRDiffTool.parameters;
       expect(params.properties.owner).toBeDefined();
       expect(params.properties.repo).toBeDefined();
       expect(params.properties.pull_number).toBeDefined();
       expect(params.properties.max_lines).toBeDefined();
       expect(params.properties.ignore_files).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required.length).toBe(0);
-      }
+      // All fields are required-but-nullable under strict sampling.
+      expectStrictTool(getPRDiffTool);
     });
 
     test('returns cancellation message when signal is aborted', async () => {
@@ -415,28 +410,31 @@ describe('extFactory', () => {
       expect(params.required).toContain('comments');
     });
 
-    test('parameters - pull_number is optional', () => {
-      const params = createReviewTool.parameters;
-      expect(params.properties.pull_number).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required).not.toContain('pull_number');
-      }
+    test('parameters - pull_number is required-but-nullable', () => {
+      expectRequiredNullable(createReviewTool, 'pull_number');
     });
 
-    test('parameters - body is optional', () => {
-      const params = createReviewTool.parameters;
-      expect(params.properties.body).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required).not.toContain('body');
-      }
+    test('parameters - body is required-but-nullable', () => {
+      expectRequiredNullable(createReviewTool, 'body');
     });
 
-    test('parameters - event is optional', () => {
-      const params = createReviewTool.parameters;
-      expect(params.properties.event).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required).not.toContain('event');
-      }
+    test('parameters - event is required-but-nullable', () => {
+      expectRequiredNullable(createReviewTool, 'event');
+    });
+
+    test('schema is strict-compatible (additionalProperties:false, strict sampling, nullable comment fields)', () => {
+      expectStrictTool(createReviewTool);
+      // Nested review-comment schema is strict-compatible too: side / start_line /
+      // start_side are nullable, and additionalProperties is false.
+      const commentSchema = (
+        createReviewTool.parameters.properties.comments as unknown as {
+          items?: { additionalProperties?: boolean; required?: string[] };
+        }
+      ).items;
+      expect(commentSchema?.additionalProperties).toBe(false);
+      expect(commentSchema?.required).toEqual(
+        expect.arrayContaining(['path', 'line', 'side', 'start_line', 'start_side', 'body'])
+      );
     });
 
     test('returns cancellation message when signal is aborted', async () => {
@@ -482,7 +480,7 @@ describe('extFactory', () => {
       expect(getCIStatusTool.promptSnippet.length).toBeGreaterThan(0);
     });
 
-    test('parameters - all fields are optional', () => {
+    test('parameters - all fields are present and the schema is strict-compatible', () => {
       const params = getCIStatusTool.parameters;
       expect(params.properties.owner).toBeDefined();
       expect(params.properties.repo).toBeDefined();
@@ -490,9 +488,7 @@ describe('extFactory', () => {
       expect(params.properties.ref).toBeDefined();
       expect(params.properties.status).toBeDefined();
       expect(params.properties.conclusion).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required.length).toBe(0);
-      }
+      expectStrictTool(getCIStatusTool);
     });
 
     test('returns cancellation message when signal is aborted', async () => {
@@ -544,16 +540,14 @@ describe('extFactory', () => {
       expect(params.required).toContain('run_id');
     });
 
-    test('parameters - owner, repo, max_bytes are optional', () => {
-      const params = getWorkflowRunLogsTool.parameters;
-      expect(params.properties.owner).toBeDefined();
-      expect(params.properties.repo).toBeDefined();
-      expect(params.properties.max_bytes).toBeDefined();
-      if (Array.isArray(params.required)) {
-        expect(params.required).not.toContain('owner');
-        expect(params.required).not.toContain('repo');
-        expect(params.required).not.toContain('max_bytes');
-      }
+    test('parameters - owner, repo, max_bytes are required-but-nullable', () => {
+      expectRequiredNullable(getWorkflowRunLogsTool, 'owner');
+      expectRequiredNullable(getWorkflowRunLogsTool, 'repo');
+      expectRequiredNullable(getWorkflowRunLogsTool, 'max_bytes');
+    });
+
+    test('schema is strict-compatible (additionalProperties:false, strict sampling)', () => {
+      expectStrictTool(getWorkflowRunLogsTool);
     });
 
     test('returns cancellation message when signal is aborted', async () => {

--- a/packages/pi-orchestrator/tests/pi/tools/create-pr-execution.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/tools/create-pr-execution.spec.ts
@@ -34,12 +34,15 @@ describe('create_pull_request tool - execution', () => {
     expect(typeof githubIndex.createPullRequest).toBe('function');
   });
 
-  test('parameters schema validates title as required', () => {
+  test('parameters schema is strict-compatible (title required, others required-but-nullable)', () => {
     const schema = createPRTool.parameters as any;
-    expect(schema.required).toContain('title');
-    expect(schema.required).not.toContain('body');
-    expect(schema.required).not.toContain('base');
-    expect(schema.required).not.toContain('dryRun');
+    // Under strict sampling every property is required; optionals become nullable.
+    expect(schema.required).toEqual(expect.arrayContaining(['title', 'body', 'base', 'dryRun']));
+    expect(schema.additionalProperties).toBe(false);
+    expect(createPRTool.constrainedSampling).toEqual({ type: 'json_schema', strict: 'prefer' });
+    // title stays a plain string (not nullable); body/base/dryRun are nullable.
+    expect(schema.properties.title.type).toBe('string');
+    expect(schema.properties.body.anyOf?.some((m: any) => m.type === 'null')).toBe(true);
   });
 
   test('execute calls provider.createPullRequest with title only', async () => {

--- a/packages/pi-orchestrator/tests/pi/tools/get-pr-diff-execute.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/tools/get-pr-diff-execute.spec.ts
@@ -29,6 +29,27 @@ function buildProvider(diff: string): {
   return { provider, getPRDiff };
 }
 
+/**
+ * Build tool params for {@link executeGetPRDiff}.
+ *
+ * The tool's schema is strict-compatible (all properties required-but-nullable),
+ * so its parameter type requires every key. Tests only set a subset, so default
+ * the rest to `null` — the handler treats `null` and `undefined` identically
+ * via nullish-coalescing, mirroring how strict-capable providers emit absent
+ * fields.
+ */
+const diffParams = (
+  overrides: Partial<Parameters<typeof executeGetPRDiff>[0]> = {}
+): Parameters<typeof executeGetPRDiff>[0] =>
+  ({
+    owner: null,
+    repo: null,
+    pull_number: null,
+    max_lines: null,
+    ignore_files: null,
+    ...overrides,
+  }) as Parameters<typeof executeGetPRDiff>[0];
+
 describe('executeGetPRDiff (extracted handler)', () => {
   test('returns a resolve-failure result when owner/repo/pull_number are all absent', async () => {
     const getPRDiff = vi.fn(async () => 'unused');
@@ -50,7 +71,7 @@ describe('executeGetPRDiff (extracted handler)', () => {
       { issueNumber: 0 }
     );
 
-    const result = await executeGetPRDiff({}, providerNoCtx);
+    const result = await executeGetPRDiff(diffParams(), providerNoCtx);
 
     expect(result.content).toHaveLength(1);
     expect(result.content[0]!.text).toContain('Could not resolve PR');
@@ -60,7 +81,10 @@ describe('executeGetPRDiff (extracted handler)', () => {
 
   test('returns a no-diff result when the provider resolves an empty diff', async () => {
     const { provider, getPRDiff } = buildProvider('');
-    const result = await executeGetPRDiff({ owner: 'o', repo: 'r', pull_number: 7 }, provider);
+    const result = await executeGetPRDiff(
+      diffParams({ owner: 'o', repo: 'r', pull_number: 7 }),
+      provider
+    );
 
     expect(result.content[0]!.text).toContain('No diff available for PR #7');
     expect(result.details).toMatchObject({ pull_number: 7, lines: 0, truncated: false });
@@ -70,7 +94,10 @@ describe('executeGetPRDiff (extracted handler)', () => {
   test('renders the diff fenced in a ```diff block and reports line count', async () => {
     const diff = 'diff --git a/f b/f\n+hello\n';
     const { provider } = buildProvider(diff);
-    const result = await executeGetPRDiff({ owner: 'o', repo: 'r', pull_number: 9 }, provider);
+    const result = await executeGetPRDiff(
+      diffParams({ owner: 'o', repo: 'r', pull_number: 9 }),
+      provider
+    );
 
     expect(result.content[0]!.text).toBe('PR #9 Diff:\n```diff\n' + diff + '\n```');
     expect(result.details).toMatchObject({ pull_number: 9, truncated: false });
@@ -80,7 +107,7 @@ describe('executeGetPRDiff (extracted handler)', () => {
   test('forwards merged ignore_files to the provider and echoes them in details', async () => {
     const { provider, getPRDiff } = buildProvider('diff body');
     await executeGetPRDiff(
-      { owner: 'o', repo: 'r', pull_number: 1, ignore_files: ['dist/', 'lock'] },
+      diffParams({ owner: 'o', repo: 'r', pull_number: 1, ignore_files: ['dist/', 'lock'] }),
       provider,
       { diffIgnorePatterns: ['dist/', 'node_modules/'] } as DiffConfig
     );
@@ -94,7 +121,7 @@ describe('executeGetPRDiff (extracted handler)', () => {
     const longDiff = Array.from({ length: 50 }, (_, i) => `line ${i}`).join('\n');
     const { provider } = buildProvider(longDiff);
     const result = await executeGetPRDiff(
-      { owner: 'o', repo: 'r', pull_number: 3, max_lines: 10 },
+      diffParams({ owner: 'o', repo: 'r', pull_number: 3, max_lines: 10 }),
       provider
     );
 
@@ -109,7 +136,7 @@ describe('executeGetPRDiff (extracted handler)', () => {
     });
     const provider = createMockProvider({ getPRDiff }, providerOptions);
     await expect(
-      executeGetPRDiff({ owner: 'o', repo: 'r', pull_number: 1 }, provider)
+      executeGetPRDiff(diffParams({ owner: 'o', repo: 'r', pull_number: 1 }), provider)
     ).rejects.toThrow('boom');
   });
 });

--- a/packages/pi-orchestrator/tests/pi/tools/get-thread-execution.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/tools/get-thread-execution.spec.ts
@@ -66,11 +66,16 @@ describe('get_issue_or_pr_thread tool - execution', () => {
     expect(typeof githubIndex.getIssueOrPRThread).toBe('function');
   });
 
-  test('parameters schema - all fields are optional', () => {
+  test('parameters schema is strict-compatible (all fields required-but-nullable)', () => {
     const schema = getIssueOrPRThreadTool.parameters as any;
-    if (Array.isArray(schema.required)) {
-      expect(schema.required.length).toBe(0);
-    }
+    expect(schema.additionalProperties).toBe(false);
+    expect(getIssueOrPRThreadTool.constrainedSampling).toEqual({
+      type: 'json_schema',
+      strict: 'prefer',
+    });
+    expect(schema.required).toEqual(
+      expect.arrayContaining(['owner', 'repo', 'issue_number', 'max_comments'])
+    );
   });
 
   test('execute returns formatted thread when found', async () => {

--- a/packages/pi-orchestrator/tests/pi/tools/update-pr-execution.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/tools/update-pr-execution.spec.ts
@@ -35,11 +35,16 @@ describe('update_pull_request tool - execution', () => {
     expect(typeof githubIndex.updatePullRequest).toBe('function');
   });
 
-  test('parameters schema - all fields are optional', () => {
+  test('parameters schema is strict-compatible (all fields required-but-nullable)', () => {
     const schema = updatePullRequestTool.parameters as any;
-    if (Array.isArray(schema.required)) {
-      expect(schema.required.length).toBe(0);
-    }
+    expect(schema.additionalProperties).toBe(false);
+    expect(updatePullRequestTool.constrainedSampling).toEqual({
+      type: 'json_schema',
+      strict: 'prefer',
+    });
+    expect(schema.required).toEqual(
+      expect.arrayContaining(['pull_number', 'title', 'body', 'message', 'dryRun'])
+    );
   });
 
   test('execute calls provider.updatePullRequest with empty params when nothing provided', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: workspace:*
         version: link:packages/pi-platform-github
       '@earendil-works/pi-agent-core':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
     devDependencies:
       '@actions/github':
         specifier: ^9.1.1
@@ -97,14 +97,14 @@ importers:
         specifier: workspace:*
         version: link:../pi-platform-github
       '@earendil-works/pi-agent-core':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
@@ -129,8 +129,8 @@ importers:
         version: 3.36.0(supports-color@7.2.0)
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       typebox:
         specifier: ^1.3.6
         version: 1.3.6
@@ -144,14 +144,14 @@ importers:
         specifier: workspace:*
         version: link:../pi-platform-github
       '@earendil-works/pi-agent-core':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
@@ -168,14 +168,14 @@ importers:
   packages/pi-orchestrator:
     dependencies:
       '@earendil-works/pi-agent-core':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.81.1
-        version: 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
@@ -383,22 +383,22 @@ packages:
     resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
     engines: {node: '>=22'}
 
-  '@earendil-works/pi-agent-core@0.81.1':
-    resolution: {integrity: sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==}
+  '@earendil-works/pi-agent-core@0.82.1':
+    resolution: {integrity: sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.81.1':
-    resolution: {integrity: sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.81.1':
-    resolution: {integrity: sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==}
+  '@earendil-works/pi-ai@0.82.1':
+    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.81.1':
-    resolution: {integrity: sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg==}
+  '@earendil-works/pi-coding-agent@0.82.1':
+    resolution: {integrity: sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.82.1':
+    resolution: {integrity: sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -3080,7 +3080,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.6
       '@smithy/fetch-http-handler': 5.6.8
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.9.8
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3283,9 +3283,10 @@ snapshots:
 
   '@conventional-changelog/template@1.2.1': {}
 
-  '@earendil-works/pi-agent-core@0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -3297,7 +3298,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -3318,11 +3319,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.81.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.81.1
+      '@earendil-works/pi-agent-core': 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.82.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.82.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -3348,7 +3349,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.81.1':
+  '@earendil-works/pi-tui@0.82.1':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
 
   packages/pi-action-bridge:
     dependencies:
+      '@alexanderfortin/pi-orchestrator':
+        specifier: workspace:*
+        version: link:../pi-orchestrator
       '@alexanderfortin/pi-platform-github':
         specifier: workspace:*
         version: link:../pi-platform-github


### PR DESCRIPTION
- bump @earendil-works/pi-* 0.81.1 -> 0.82.1
- all 7 tools: strict-compatible schemas + constrainedSampling (prefer)
- agent: log auto_retry_start/end from the session stream