### PR TITLE
fix: dispose Pi sessions after orchestration

### DIFF
--- a/packages/pi-cli/tests/commands/run-integration.spec.ts
+++ b/packages/pi-cli/tests/commands/run-integration.spec.ts
@@ -84,6 +84,7 @@ vi.mock('../../src/adapters/pi-agent.js', () => ({
       getSessionStats: () => undefined,
       exportSessionHtml: () => Promise.resolve(''),
       exportSessionJsonl: () => Promise.resolve(''),
+      dispose: () => {},
     };
   },
 }));

--- a/packages/pi-orchestrator/src/orchestrator.ts
+++ b/packages/pi-orchestrator/src/orchestrator.ts
@@ -128,6 +128,27 @@ export class ActionOrchestrator {
     } catch (e) {
       await this.handleUncaughtError(e, startTime, reaction, pi);
       throw e;
+    } finally {
+      this.disposeAgentBestEffort(pi);
+    }
+  }
+
+  /**
+   * Dispose the Pi session after all exports, usage collection, and finalization
+   * are complete. Disposal closes provider-owned resources such as the OpenAI
+   * Codex WebSocket cache, whose five-minute idle timer otherwise keeps a
+   * headless Node.js process alive after the review has finished.
+   */
+  private disposeAgentBestEffort(pi: PiAgent | undefined): void {
+    if (!pi) {
+      return;
+    }
+
+    try {
+      pi.dispose();
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      this.logger.notice(`failed to dispose Pi agent session: ${errorMessage}`);
     }
   }
 

--- a/packages/pi-orchestrator/src/pi/agent.ts
+++ b/packages/pi-orchestrator/src/pi/agent.ts
@@ -384,6 +384,17 @@ export class Agent {
   }
 
   /**
+   * Release the underlying SDK session and its provider resources.
+   *
+   * In particular, the OpenAI Codex transport caches a reusable WebSocket
+   * for five minutes. `AgentSession.dispose()` closes that socket and clears
+   * its expiry timer so headless callers can exit immediately.
+   */
+  dispose(): void {
+    this.session?.dispose();
+  }
+
+  /**
    * Handle `message_update` session events.
    *
    * Routes text deltas to the output buffer and thinking deltas/completion
@@ -615,6 +626,9 @@ export function wrapAgent(agent: Agent): PiAgent {
     },
     async exportSessionJsonl(outputPath: string) {
       return agent.exportSessionJsonl(outputPath);
+    },
+    dispose() {
+      agent.dispose();
     },
   };
 }

--- a/packages/pi-orchestrator/src/types.ts
+++ b/packages/pi-orchestrator/src/types.ts
@@ -112,6 +112,8 @@ export interface PiAgent {
   exportSessionHtml(outputPath: string): Promise<string>;
   /** Export the session as a JSONL file to the given path. */
   exportSessionJsonl(outputPath: string): Promise<string>;
+  /** Release the underlying session and any provider resources it owns. */
+  dispose(): void;
 }
 
 /**

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -133,11 +133,13 @@ describe('ActionOrchestrator', () => {
     const exportSessionHtmlMock = vi.fn(async (outputPath: string) => outputPath);
     const exportSessionJsonlMock = vi.fn(async (outputPath: string) => outputPath);
     const getSessionStatsMock = vi.fn(() => undefined);
+    const disposeMock = vi.fn();
     mockPiAgent = {
       run: runMock as any,
       getSessionStats: getSessionStatsMock as any,
       exportSessionHtml: exportSessionHtmlMock as any,
       exportSessionJsonl: exportSessionJsonlMock as any,
+      dispose: disposeMock,
     };
 
     mockPiFactory = vi.fn(() => mockPiAgent);
@@ -273,6 +275,36 @@ describe('ActionOrchestrator', () => {
       await orchestrator.execute();
 
       expect(mockGit.deleteReaction).toHaveBeenCalledWith(mockReaction);
+    });
+
+    test('disposes the Pi session after successful finalization', async () => {
+      const orchestrator = createOrchestrator();
+      await orchestrator.execute();
+
+      expect(mockPiAgent.dispose).toHaveBeenCalledTimes(1);
+      expect(mockGit.createFinalComment).toHaveBeenCalledBefore(mockPiAgent.dispose as any);
+    });
+
+    test('disposes the Pi session when the run throws', async () => {
+      setAgentRunError(mockPiAgent, new Error('API error'));
+
+      const orchestrator = createOrchestrator();
+      await expect(orchestrator.execute()).rejects.toThrow('API error');
+
+      expect(mockPiAgent.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not fail a successful run when session disposal throws', async () => {
+      (mockPiAgent.dispose as any).mockImplementation(() => {
+        throw new Error('close failed');
+      });
+
+      const orchestrator = createOrchestrator();
+      await expect(orchestrator.execute()).resolves.toBeUndefined();
+
+      expect(mockCore.notice).toHaveBeenCalledWith(
+        'failed to dispose Pi agent session: close failed'
+      );
     });
 
     test('logs agent session completed banner after successful run', async () => {

--- a/packages/pi-orchestrator/tests/orchestrator.spec.ts
+++ b/packages/pi-orchestrator/tests/orchestrator.spec.ts
@@ -307,6 +307,19 @@ describe('ActionOrchestrator', () => {
       );
     });
 
+    test('logs non-Error session disposal failures', async () => {
+      (mockPiAgent.dispose as any).mockImplementation(() => {
+        throw 'close failed';
+      });
+
+      const orchestrator = createOrchestrator();
+      await expect(orchestrator.execute()).resolves.toBeUndefined();
+
+      expect(mockCore.notice).toHaveBeenCalledWith(
+        'failed to dispose Pi agent session: close failed'
+      );
+    });
+
     test('logs agent session completed banner after successful run', async () => {
       const orchestrator = createOrchestrator();
       await orchestrator.execute();

--- a/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/agent-logic.spec.ts
@@ -982,6 +982,24 @@ describe('Agent', () => {
     });
   });
 
+  describe('dispose', () => {
+    test('disposes the underlying SDK session', () => {
+      const agent = new Agent(mockCoreAdapter as any, mockPlatformProvider, defaultAgentConfig);
+      const dispose = vi.fn();
+      (agent as unknown as { session: { dispose: () => void } }).session = { dispose };
+
+      agent.dispose();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    test('is safe before the SDK session is initialized', () => {
+      const agent = new Agent(mockCoreAdapter as any, mockPlatformProvider, defaultAgentConfig);
+
+      expect(() => agent.dispose()).not.toThrow();
+    });
+  });
+
   describe('exportSessionJsonl', () => {
     test('delegates to session.exportToJsonl', async () => {
       const agent = createRealAgent();

--- a/packages/pi-orchestrator/tests/pi/wrap-agent.spec.ts
+++ b/packages/pi-orchestrator/tests/pi/wrap-agent.spec.ts
@@ -22,6 +22,7 @@ function createStubAgent(
     getSessionStats: Agent['getSessionStats'];
     exportSessionHtml: Agent['exportSessionHtml'];
     exportSessionJsonl: Agent['exportSessionJsonl'];
+    dispose: Agent['dispose'];
   }> = {}
 ): Agent {
   return {
@@ -32,6 +33,7 @@ function createStubAgent(
     getSessionStats: overrides.getSessionStats ?? vi.fn(() => undefined),
     exportSessionHtml: overrides.exportSessionHtml ?? vi.fn(async () => '/tmp/out.html'),
     exportSessionJsonl: overrides.exportSessionJsonl ?? vi.fn(async () => '/tmp/out.jsonl'),
+    dispose: overrides.dispose ?? vi.fn(),
   } as unknown as Agent;
 }
 
@@ -52,6 +54,7 @@ describe('wrapAgent', () => {
     }));
     const exportSessionHtml = vi.fn(async () => '/tmp/session.html');
     const exportSessionJsonl = vi.fn(async () => '/tmp/session.jsonl');
+    const dispose = vi.fn();
 
     const agent = createStubAgent({
       ready,
@@ -59,6 +62,7 @@ describe('wrapAgent', () => {
       getSessionStats,
       exportSessionHtml,
       exportSessionJsonl,
+      dispose,
     });
 
     const wrapped: PiAgent = wrapAgent(agent);
@@ -77,6 +81,7 @@ describe('wrapAgent', () => {
     });
     expect(await wrapped.exportSessionHtml('/x')).toBe('/tmp/session.html');
     expect(await wrapped.exportSessionJsonl('/y')).toBe('/tmp/session.jsonl');
+    wrapped.dispose();
 
     expect(ready).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledTimes(1);
@@ -84,6 +89,7 @@ describe('wrapAgent', () => {
     expect(getSessionStats).toHaveBeenCalledTimes(1);
     expect(exportSessionHtml).toHaveBeenCalledWith('/x');
     expect(exportSessionJsonl).toHaveBeenCalledWith('/y');
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 
   test('run() always calls ready() before run()', async () => {


### PR DESCRIPTION

   ## Summary

   Dispose the Pi SDK session after orchestration finishes, including when execution fails.

   ## Problem

   OpenAI Codex sessions can retain an active WebSocket and its associated 300-second timer after the
 agent has completed. Because the action did not dispose `AgentSession`, the Node process remained alive
 for approximately five minutes after producing the review.

   ## Changes

   - Add `dispose()` to the `PiAgent` interface.
   - Implement `PiAgent.dispose()` by delegating to `AgentSession.dispose()`.
   - Dispose the agent in `ActionOrchestrator.execute()` using `finally`.
   - Preserve the original execution error if disposal also fails.
   - Add lifecycle coverage for successful, failed, and mocked executions.

   ## Validation

   - `pnpm run validate`
   - 187 focused orchestrator and CLI tests passed.

   ## Result

   The action exits promptly after completing an OpenAI Codex session instead of waiting for the
 retained 300-second timer.