### PR TITLE
fix(release): resolve tsx not found in semantic-release prepareCmd

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,7 +20,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "tsx scripts/bump-readme-version.ts ${nextRelease.version} && pnpm run sync-versions && pnpm run sync-lockfile && pnpm run update-readme && pnpm run package"
+        "prepareCmd": "pnpm exec tsx scripts/bump-readme-version.ts ${nextRelease.version} && pnpm run sync-versions && pnpm run sync-lockfile && pnpm run update-readme && pnpm run package"
       }
     ],
     [

--- a/scripts/bump-readme-version.ts
+++ b/scripts/bump-readme-version.ts
@@ -4,8 +4,11 @@
  *
  * Called by the @semantic-release/exec plugin during the release process.
  * The next version is passed as the first CLI argument by the `prepareCmd`
- * (`tsx scripts/bump-readme-version.ts ${nextRelease.version}`), or read from
- * the `npm_package_version` env var set by semantic-release.
+ * (`pnpm exec tsx scripts/bump-readme-version.ts ${nextRelease.version}`),
+ * or read from the `npm_package_version` env var set by semantic-release.
+ * `pnpm exec` is required so the local `node_modules/.bin/tsx` binary is on
+ * PATH — the exec plugin runs prepareCmd via the system shell, which does not
+ * include `node_modules/.bin` (unlike `pnpm run <script>`).
  *
  * Note: package.json version bumping is handled by @semantic-release/npm
  * with npmPublish:false, so this script only needs to handle README.md.


### PR DESCRIPTION
## Summary

Fixes the failing promote/release workflow, which crashed during semantic-release with:

```
/bin/sh: 1: tsx: not found
```

## Root cause

In the Bun → Node/pnpm migration (#392), the `@semantic-release/exec` plugin's `prepareCmd` in `.releaserc.json` was rewritten from:

```
bun run scripts/bump-readme-version.ts ... && bun run sync-versions && ...
```

to:

```
tsx scripts/bump-readme-version.ts ... && pnpm run sync-versions && ...
```

The problem: the `@semantic-release/exec` plugin runs `prepareCmd` via the system shell (`/bin/sh -c ...`), whose `PATH` does **not** include `node_modules/.bin`. The other commands in the chain (`pnpm run sync-versions`, etc.) work because `pnpm run <script>` prepends `node_modules/.bin` to `PATH` — but the bare `tsx` call has no such resolution and fails.

## Fix

Change the bare `tsx ...` invocation to `pnpm exec tsx ...`, so the local `node_modules/.bin/tsx` binary is resolved on `PATH`, consistent with the `pnpm run` calls that already work.

## Verification

Reproduced the exact failure and confirmed the fix by simulating how the exec plugin spawns the command:

```
$ /bin/sh -c "tsx scripts/bump-readme-version.ts 9.9.9"
/bin/sh: 1: tsx: not found          # ← reproduces the bug (exit 127)

$ /bin/sh -c "pnpm exec tsx scripts/bump-readme-version.ts 9.9.9"
Updated README.md pinned version reference to v9.9.9   # ← fix works ✓
```

Also updated the now-stale doc comment in `scripts/bump-readme-version.ts` to reflect the new invocation and explain *why* `pnpm exec` is required.

`pnpm run validate` (lint + type-check + prettier) passes.

Fixes #396