### PR TITLE
fix(github): recover missing PR context from event payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ The action extends Pi with the following built-in GitHub tools:
 
 | Tool | Description |
 |------|-------------|
-| `create_pull_request_review` | Creates a pull request review with inline comments anchored to specific lines of the diff. Posts a GitHub Pull Request Review using the `pulls.createReview` API with comments positioned on specific file paths and line numbers. Supports multi-line comments, diff side selection (LEFT/RIGHT), and review events (COMMENT, APPROVE, REQUEST_CHANGES). |
+| `create_pull_request_review` | Creates a pull request review with a summary body, inline comments anchored to specific diff lines, or both. Posts a GitHub Pull Request Review using the `pulls.createReview` API. Supports summary-only reviews, multi-line comments, diff side selection (LEFT/RIGHT), and review events (COMMENT, APPROVE, REQUEST_CHANGES). |
 | `create_pull_request` | Creates a new pull request by detecting file changes, creating a branch, committing changes via GitHub API, and opening the PR. Supports `dry_run` mode for testing without actual PR creation. |
 | `get_ci_status` | Checks the CI/CD status for a pull request or commit ref. Returns both check runs and workflow runs with their statuses, conclusions, and URLs. Accepts optional `pull_number`, `ref`, `status`, and `conclusion` filters. For failed workflow runs, use the returned `run_id` with `get_workflow_run_logs` to fetch detailed job logs. |
 | `get_issue_or_pr_thread` | Retrieves the full thread of an issue or pull request including title, body, state, labels, branch info (for PRs), all comments, and review comments (inline comments on specific lines of the diff) for PRs. Useful for understanding the full context before making changes. |

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -256,7 +256,7 @@ export const GET_PR_DIFF_PARAM_IGNORE_FILES_DESCRIPTION =
 // Create Pull Request Review
 //
 export const CREATE_REVIEW_PROMPT_SNIPPET =
-  'Create a pull request review with inline comments anchored to specific lines of the diff. This is the best way to provide line-by-line code review feedback.';
+  'Create a pull request review with an optional summary and inline comments anchored to specific lines of the diff.';
 
 export const CREATE_REVIEW_PROMPT_GUIDELINES = [
   'Use create_pull_request_review to post inline review comments anchored to specific diff lines. This is much more useful than top-level comments because reviewers can see findings directly in the diff context.',
@@ -265,7 +265,7 @@ export const CREATE_REVIEW_PROMPT_GUIDELINES = [
   'For multi-line comments, set `start_line` to the first line and `line` to the last line of the range.',
   'The `event` parameter controls the review type: COMMENT (default, neutral feedback), APPROVE (approve the PR), or REQUEST_CHANGES (request changes before merging).',
   'A `body` (summary comment) is optional but recommended — it provides context for the overall review.',
-  'At least one inline comment is required. To post only a summary review comment without inline comments, use a regular PR comment instead.',
+  'Provide at least one inline comment or a non-empty `body`. A summary-only review may use an empty `comments` array.',
   'Make sure line numbers reference the correct version of the file. Use the `get_pr_diff` tool first to understand the diff and verify line numbers.',
 ];
 
@@ -280,7 +280,7 @@ export const CREATE_REVIEW_PROMPT_GUIDELINES = [
  */
 export function CREATE_REVIEW_DESCRIPTION(platform: PlatformType = 'github'): string {
   const product = productNameOf(platform);
-  return `Create a pull request review with inline comments anchored to specific lines of the diff. Posts a ${product} Pull Request Review using the \`pulls.createReview\` API with comments positioned on specific lines. Each comment is anchored to a file path and line number in the diff.`;
+  return `Create a pull request review with an optional summary and optional inline comments anchored to specific lines of the diff. Posts a ${product} Pull Request Review using the \`pulls.createReview\` API. Provide at least one inline comment or a non-empty summary body.`;
 }
 
 export const CREATE_REVIEW_PARAM_PULL_NUMBER_DESCRIPTION =
@@ -293,7 +293,7 @@ export const CREATE_REVIEW_PARAM_EVENT_DESCRIPTION =
   'Review event type: COMMENT (default, neutral feedback), APPROVE (approve the PR), or REQUEST_CHANGES (request changes before merging).';
 
 export const CREATE_REVIEW_PARAM_COMMENTS_DESCRIPTION =
-  'Array of inline comments. Each comment requires: path (file path), line (line number in the diff), and body (Markdown comment). Optional: side (LEFT=old or RIGHT=new, default RIGHT), start_line (for multi-line comments).';
+  'Array of inline comments. May be empty when the review body is non-empty. Each comment requires: path (file path), line (line number in the diff), and body (Markdown comment). Optional: side (LEFT=old or RIGHT=new, default RIGHT), start_line (for multi-line comments).';
 
 export const CREATE_REVIEW_PARAM_COMMENT_PATH_DESCRIPTION =
   'Repository-relative file path (e.g., "src/main.ts").';

--- a/packages/pi-orchestrator/src/pi/tools/create-review.ts
+++ b/packages/pi-orchestrator/src/pi/tools/create-review.ts
@@ -84,7 +84,7 @@ const createReviewSchema = Type.Object(
     ),
     comments: Type.Array(reviewCommentSchema, {
       description:
-        'Array of inline comments anchored to diff lines. Each requires path, line, and body.',
+        'Array of inline comments anchored to diff lines. May be empty when body is non-empty. Each comment requires path, line, and body.',
     }),
   },
   { additionalProperties: false }

--- a/packages/pi-orchestrator/src/platform/types.ts
+++ b/packages/pi-orchestrator/src/platform/types.ts
@@ -206,7 +206,7 @@ export interface CreateReviewParams {
   body?: string;
   /** Review event: COMMENT (default), APPROVE, or REQUEST_CHANGES. */
   event?: 'COMMENT' | 'APPROVE' | 'REQUEST_CHANGES';
-  /** Inline comments anchored to specific diff lines. At least one is required. */
+  /** Inline comments anchored to specific diff lines. May be empty when body is non-empty. */
   comments: ReviewInlineComment[];
 }
 

--- a/packages/pi-platform-github/src/context-utils.ts
+++ b/packages/pi-platform-github/src/context-utils.ts
@@ -5,7 +5,103 @@
  * dependency injection — no module-level singletons or `@actions/*` imports.
  */
 
+import type { PlatformContext } from '@alexanderfortin/pi-orchestrator';
 import type { GitHubModuleDeps } from './types';
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined;
+  }
+
+  return value.trim();
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function repositoryFromPayload(payload: Record<string, unknown>): {
+  owner?: string;
+  repo?: string;
+} {
+  const repository = asRecord(payload.repository);
+  if (!repository) {
+    return {};
+  }
+
+  const fullName = asNonEmptyString(repository.full_name);
+  if (fullName) {
+    const parts = fullName.split('/');
+    if (parts.length === 2) {
+      const owner = asNonEmptyString(parts[0]);
+      const repo = asNonEmptyString(parts[1]);
+      if (owner && repo) {
+        return { owner, repo };
+      }
+    }
+  }
+
+  const owner = asRecord(repository.owner);
+  const ownerLogin = asNonEmptyString(owner?.login);
+  const repoName = asNonEmptyString(repository.name);
+
+  return {
+    ...(ownerLogin ? { owner: ownerLogin } : {}),
+    ...(repoName ? { repo: repoName } : {}),
+  };
+}
+
+function issueNumberFromPayload(payload: Record<string, unknown>): number | undefined {
+  const pullRequest = asRecord(payload.pull_request);
+  const issue = asRecord(payload.issue);
+
+  return (
+    asPositiveInteger(pullRequest?.number) ??
+    asPositiveInteger(issue?.number) ??
+    asPositiveInteger(payload.number)
+  );
+}
+
+/**
+ * Recover repository and issue/PR identifiers from a webhook payload when a
+ * frontend provides an incomplete platform context.
+ *
+ * Explicit context values always win. The payload is only a fallback so CLI
+ * and non-Actions frontends can continue to supply their own context.
+ */
+export function resolvePlatformContext(context: PlatformContext): PlatformContext {
+  const payloadRepository = repositoryFromPayload(context.payload);
+  const owner = asNonEmptyString(context.repo.owner) ?? payloadRepository.owner ?? '';
+  const repo = asNonEmptyString(context.repo.repo) ?? payloadRepository.repo ?? '';
+  const issueNumber =
+    asPositiveInteger(context.issue.number) ?? issueNumberFromPayload(context.payload) ?? 0;
+
+  if (
+    owner === context.repo.owner &&
+    repo === context.repo.repo &&
+    issueNumber === context.issue.number
+  ) {
+    return context;
+  }
+
+  return {
+    ...context,
+    repo: { owner, repo },
+    issue: { number: issueNumber },
+  };
+}
 
 /**
  * Determine if the current GitHub context is a pull request.

--- a/packages/pi-platform-github/src/provider.ts
+++ b/packages/pi-platform-github/src/provider.ts
@@ -23,6 +23,7 @@ import { fetchPRDiff } from './tools/pr-diff';
 import { createReview } from './tools/review';
 import { getCIStatus } from './tools/get-ci-status';
 import { getWorkflowRunLogs } from './tools/get-workflow-run-logs';
+import { resolvePlatformContext } from './context-utils';
 import type { Temporal } from '@js-temporal/polyfill';
 import type { Logger } from '@alexanderfortin/pi-orchestrator';
 import type {
@@ -212,10 +213,15 @@ export interface GitHubPlatformDeps {
 export function createGitHubPlatformProvider(deps: GitHubPlatformDeps): PlatformProvider {
   const type = deps.platformType;
 
-  // Use the provided deps directly — no fallbacks
-  const resolvedContext = deps.context;
+  const resolvedContext = resolvePlatformContext(deps.context);
   const logger = deps.logger;
   const octokit = deps.octokit;
+
+  if (resolvedContext !== deps.context) {
+    logger.debug(
+      `[createGitHubPlatformProvider] Recovered missing context from event payload: ${resolvedContext.repo.owner}/${resolvedContext.repo.repo}#${resolvedContext.issue.number}`
+    );
+  }
 
   // Resolve the trigger
   const trigger = deps?.trigger;

--- a/packages/pi-platform-github/src/tools/review.ts
+++ b/packages/pi-platform-github/src/tools/review.ts
@@ -58,8 +58,13 @@ export function validateReviewEvent(event: string | undefined): void {
  * @internal Exported for testing purposes.
  */
 export function validateCreateReviewParams(params: CreateReviewParams): void {
-  if (!params.comments || params.comments.length === 0) {
-    throw new Error('At least one inline comment is required to create a review');
+  const hasInlineComments = params.comments.length > 0;
+  const hasSummary = typeof params.body === 'string' && params.body.trim() !== '';
+
+  if (!hasInlineComments && !hasSummary) {
+    throw new Error(
+      'At least one inline comment or a non-empty review body is required to create a review'
+    );
   }
   params.comments.forEach((comment, i) => validateReviewComment(comment, i));
   validateReviewEvent(params.event);

--- a/packages/pi-platform-github/tests/provider.spec.ts
+++ b/packages/pi-platform-github/tests/provider.spec.ts
@@ -145,6 +145,94 @@ describe('createGitHubPlatformProvider', () => {
     );
     expect(provider.type).toBe('github');
   });
+
+  test('recovers missing repository and PR context from the event payload', () => {
+    const provider = createGitHubPlatformProvider(
+      makeMockDeps({
+        context: {
+          ...makeMockDeps().context,
+          repo: { owner: '', repo: '' },
+          issue: { number: 0 },
+          eventName: 'pull_request',
+          payload: {
+            number: 123,
+            pull_request: { number: 123 },
+            repository: {
+              full_name: 'example-org/example-repo',
+              name: 'example-repo',
+              owner: { login: 'example-org' },
+            },
+          },
+        },
+      })
+    );
+
+    expect(provider.getContext().repo).toEqual({
+      owner: 'example-org',
+      repo: 'example-repo',
+    });
+    expect(provider.getContext().issue).toEqual({ number: 123 });
+  });
+
+  test('falls back to repository owner and name when full_name is unavailable', () => {
+    const provider = createGitHubPlatformProvider(
+      makeMockDeps({
+        context: {
+          ...makeMockDeps().context,
+          repo: { owner: '', repo: '' },
+          issue: { number: 0 },
+          payload: {
+            issue: { number: 42 },
+            repository: {
+              name: 'project',
+              owner: { login: 'organization' },
+            },
+          },
+        },
+      })
+    );
+
+    expect(provider.getContext().repo).toEqual({ owner: 'organization', repo: 'project' });
+    expect(provider.getContext().issue).toEqual({ number: 42 });
+  });
+
+  test('preserves valid explicit context when the event payload differs', () => {
+    const context = makeMockDeps().context;
+    const provider = createGitHubPlatformProvider(
+      makeMockDeps({
+        context: {
+          ...context,
+          payload: {
+            pull_request: { number: 999 },
+            repository: { full_name: 'payload-owner/payload-repo' },
+          },
+        },
+      })
+    );
+
+    expect(provider.getContext().repo).toEqual(context.repo);
+    expect(provider.getContext().issue).toEqual(context.issue);
+  });
+
+  test('leaves context unresolved when the event payload is malformed', () => {
+    const provider = createGitHubPlatformProvider(
+      makeMockDeps({
+        context: {
+          ...makeMockDeps().context,
+          repo: { owner: '', repo: '' },
+          issue: { number: 0 },
+          payload: {
+            number: 'not-a-number',
+            pull_request: { number: -1 },
+            repository: { full_name: 'not-a-valid-full-name' },
+          },
+        },
+      })
+    );
+
+    expect(provider.getContext().repo).toEqual({ owner: '', repo: '' });
+    expect(provider.getContext().issue).toEqual({ number: 0 });
+  });
 });
 
 describe('PlatformProvider interface compliance', () => {

--- a/packages/pi-platform-github/tests/review-logic.spec.ts
+++ b/packages/pi-platform-github/tests/review-logic.spec.ts
@@ -10,11 +10,23 @@ import { validateCreateReviewParams, toGitHubComment } from '@alexanderfortin/pi
 import type { CreateReviewParams, ReviewInlineComment } from '@alexanderfortin/pi-platform-github';
 
 describe('validateCreateReviewParams', () => {
-  test('throws when comments array is empty', () => {
+  test('throws when comments and review body are empty', () => {
     const params: CreateReviewParams = { comments: [] };
     expect(() => validateCreateReviewParams(params)).toThrow(
-      /At least one inline comment is required/
+      /At least one inline comment or a non-empty review body is required/
     );
+  });
+
+  test('throws when comments are empty and review body is whitespace only', () => {
+    const params: CreateReviewParams = { body: '   ', comments: [] };
+    expect(() => validateCreateReviewParams(params)).toThrow(
+      /At least one inline comment or a non-empty review body is required/
+    );
+  });
+
+  test('passes for a summary-only review', () => {
+    const params: CreateReviewParams = { body: 'No issues found.', comments: [] };
+    expect(() => validateCreateReviewParams(params)).not.toThrow();
   });
 
   test('throws when comment path is empty', () => {

--- a/packages/pi-platform-github/tests/review.spec.ts
+++ b/packages/pi-platform-github/tests/review.spec.ts
@@ -134,6 +134,24 @@ describe('createReview', () => {
     expect(callArgs.body).toBe('Overall looks good but a few nits');
   });
 
+  test('creates a summary-only review without inline comments', async () => {
+    const deps = createReviewDeps();
+    const result = await createReview(deps, {
+      body: 'No issues found.',
+      event: 'COMMENT',
+      comments: [],
+    });
+
+    const callArgs = (deps.octokit.rest.pulls.createReview as any).mock.calls[0][0];
+    expect(callArgs).toMatchObject({
+      pull_number: 42,
+      body: 'No issues found.',
+      event: 'COMMENT',
+      comments: [],
+    });
+    expect(result.details.commentCount).toBe(0);
+  });
+
   test('defaults body to empty string', async () => {
     const deps = createReviewDeps();
     await createReview(deps, {


### PR DESCRIPTION
## What changed

- recover a missing repository owner/name and issue or PR number from the GitHub event payload when constructing the platform provider
- preserve valid explicitly supplied context and use the payload only as a fallback
- allow pull-request reviews with a non-empty summary and no inline comments
- keep rejecting reviews that have neither inline comments nor a non-empty summary
- cover PR/issue context resolution and summary-only review behavior across provider, platform, and orchestration layers

## Why

A pull-request workflow can have the correct identifiers in its event payload while provider-backed tools receive blank context. Resolving the fallback at provider construction gives every built-in GitHub tool the same current-request context.

GitHub also accepts review summaries without inline comments, but local validation previously rejected them before the API call.

## Checks

- `PI_CODING_AGENT_DIR=/tmp/pi-action-agent-tests-20260807 pnpm test` - 1,736 passed, 2 skipped
- focused context and review regressions - 54 passed
- `pnpm run validate`
