### PR TITLE
GithubCI: don't run "Upload coverage to Codecov" step in forks

### DIFF
--- a/.github/workflows/build_test_coverage.yml
+++ b/.github/workflows/build_test_coverage.yml
@@ -43,6 +43,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage to Codecov
+        if: github.repository_owner == 'shaftoe'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info


### PR DESCRIPTION
Forks may not be authenticated/registered in Codecov, so skip that step instead of running it and causing CI to fail.