### PR TITLE
Create PRs from a fork if insufficient permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,21 @@ You can customize the auto-generated branch names used when Pi creates pull requ
 | `fix/{number}` | `fix/42` |
 | `{title}-{number}-{timestamp}` | `fix-auth-bug-42-1716543210000` |
 
+### Pull Requests from a Fork
+
+If there are insufficient rights to push to the repository, agent will open a PR from its own fork. The agent creates the fork automatically on first use and reuses it afterwards.
+
+1. On first use the agent creates a fork of the repository under the account that owns `github_token`; subsequent runs reuse it.
+2. The generated branch is pushed to that fork.
+3. The pull request is opened on the repository with the cross-repository head `fork-owner:branch`. `update_pull_request` pushes follow-up commits to the fork as well.
+
+This mirrors how human contributors work and keeps agent branches out of the repository's branch list.
+
+> [!IMPORTANT]
+> **A personal access token is required for PR creation.** The default `secrets.GITHUB_TOKEN` authenticates as the repository's `github-actions[bot]`, which cannot own forks — `create_pull_request` fails with an actionable error in that case. Provide a classic PAT (with the `repo` scope) or a fine-grained PAT (with repository read/write access) via the `github_token` input.
+>
+> When the token's owner already owns the repository (e.g. running the agent against your own repository with your PAT), a fork is impossible and unnecessary — the branch is pushed to the repository itself and a same-repository pull request is opened instead.
+
 ### Injecting Environment Variables
 
 Pi extensions often require environment variables for authentication or configuration. Use the native `env:` step key to pass variables from your workflow's secrets or configuration into the Pi session:
@@ -915,12 +930,12 @@ The action extends Pi with the following built-in GitHub tools:
 | Tool | Description |
 |------|-------------|
 | `create_pull_request_review` | Creates a pull request review with a summary body, inline comments anchored to specific diff lines, or both. Posts a GitHub Pull Request Review using the `pulls.createReview` API. Supports summary-only reviews, multi-line comments, diff side selection (LEFT/RIGHT), and review events (COMMENT, APPROVE, REQUEST_CHANGES). |
-| `create_pull_request` | Creates a new pull request by detecting file changes, creating a branch, committing changes via GitHub API, and opening the PR. Supports `dry_run` mode for testing without actual PR creation. |
+| `create_pull_request` | Creates a new pull request by detecting file changes, creating a branch, committing changes via GitHub API, and opening the PR. Supports `dry_run` mode for testing without actual PR creation. If there are insufficient rights to push to the repository, it will open a PR from its own fork. The tool creates the fork automatically on first use and reuses it afterwards. |
 | `get_ci_status` | Checks the CI/CD status for a pull request or commit ref. Returns both check runs and workflow runs with their statuses, conclusions, and URLs. Accepts optional `pull_number`, `ref`, `status`, and `conclusion` filters. For failed workflow runs, use the returned `run_id` with `get_workflow_run_logs` to fetch detailed job logs. |
 | `get_issue_or_pr_thread` | Retrieves the full thread of an issue or pull request including title, body, state, labels, branch info (for PRs), all comments, and review comments (inline comments on specific lines of the diff) for PRs. Useful for understanding the full context before making changes. |
 | `get_pr_diff` | Fetches the diff of a pull request on demand. Useful when the agent needs to understand what changed in a PR, e.g. for code reviews or addressing review feedback. Supports configurable `max_lines` truncation (default: 1000), max byte size cap (default: 100KB), and ignore patterns to filter out noisy paths. |
 | `get_workflow_run_logs` | Fetches job logs for a specific GitHub Actions workflow run to diagnose CI failures. Lists all jobs for a run and downloads their logs, truncated to 50KB by default (configurable via `max_bytes`). |
-| `update_pull_request` | Updates an existing pull request by pushing new commits to the PR branch and optionally updating the title and/or description. Supports `dry_run` mode for testing without actual modifications. |
+| `update_pull_request` | Updates an existing pull request by pushing new commits to the PR branch (in the fork for fork-based PRs, in the repository otherwise) and optionally updating the title and/or description. Supports `dry_run` mode for testing without actual modifications. |
 
 > [!TIP]
 > Set `load_builtin_extensions` input to `false` to disable custom tool auto loading.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 
 inputs:
   github_token:
-    description: 'GitHub token for API access. The default `GITHUB_TOKEN` works for all standard operations. To use `share_session`, provide a classic PAT (`gist` scope), fine-grained PAT (Account → Gists: read/write), or GitHub App token instead — the default `GITHUB_TOKEN` cannot create gists.'
+    description: 'GitHub token for API access. The default `GITHUB_TOKEN` works for all standard operations. To use `share_session`, provide a classic PAT (`gist` scope), fine-grained PAT (Account → Gists: read/write), or GitHub App token instead — the default `GITHUB_TOKEN` cannot create gists. To open pull requests from the agent''s own fork, a personal access token needs to be classic PAT with `repo` scope, or a fine-grained PAT with repository read/write + fork permissions.'
     required: true
 
   provider:

--- a/packages/pi-orchestrator/src/pi/prompt.ts
+++ b/packages/pi-orchestrator/src/pi/prompt.ts
@@ -88,9 +88,11 @@ export const CREATE_PULL_REQUEST_PROMPT_GUIDELINES = [
   'Always use the create_pull_request tool to create pull requests - do not use git commands or gh CLI directly.',
   'Make sure your changes are made (modified files exist) before calling this tool. The tool will detect changes, create branch, and create PR automatically. Do NOT use unless you have already applied changes and/or added new files.',
   'The tool will automatically generate a branch name in the format: pi/issue{number}-{timestamp}.',
+  "If the tool fails to push to the repository because of insufficient permissions, open a PR from a fork: create a fork (if it doesn't exist); push the PR branch to fork; create a PR from the branch in the fork.",
   'Do NOT provide the "base" parameter unless the user explicitly requests a different target branch than the repository default. The tool will automatically detect the correct default branch.',
   'Use dryRun=true first to verify the PR configuration, then dryRun=false to create it.',
   'On some platforms (e.g. Forgejo) the PR object cannot always be opened automatically even though the branch is pushed. When this happens the tool returns a compare URL instead of an error — post that URL so the user can open the PR manually.',
+  'If the tool fails with an error about creating a fork, the configured token cannot own forks (e.g. the default GITHUB_TOKEN authenticates as a bot). Report that a personal access token with repository access is required for fork-based pull requests.',
 ];
 
 /**


### PR DESCRIPTION
If there are insufficient rights to push to the repository, agent will open a PR from a fork. This mirrors how human contributors work (especially in an environment where the repo to work with is public/open but direct commit access is not, while PRs are accepted from any github user account, regardless of the permissions of the latter).